### PR TITLE
Patents Pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,6 @@ target/
 
 # NPM
 node_modules/
+
+#credentials
+credentials/

--- a/dap_aria_mapping/getters/patents.py
+++ b/dap_aria_mapping/getters/patents.py
@@ -1,60 +1,22 @@
 import pandas as pd
 from nesta_ds_utils.loading_saving.S3 import download_obj
-from dap_aria_mapping import AI_GENOMICS_BUCKET_NAME
+from dap_aria_mapping import BUCKET_NAME, AI_GENOMICS_BUCKET_NAME
 from typing import Mapping, Union
+import pandas as pd
 
 
-def get_ai_genomics_patents() -> pd.DataFrame:
-    """From S3 loads dataframe of AI in genomics patents
-    with columns such as:
-        - application_number
-        - publication_number
-        - full list of cpc codes
-        - abstract_text
-        - publication_date
-        - inventor
-        - assignee
+def get_patents() -> pd.DataFrame:
+    """From S3 loads dataframe of patents with columns such as:
+    - application_number
+    - publication_number
+    - full list of cpc codes
+    - abstract_text
+    - publication_date
+    - inventor
+    - assignee
     """
-    return download_obj(
-        AI_GENOMICS_BUCKET_NAME,
-        "inputs/patent_data/processed_patent_data/ai_genomics_patents_cpc_codes.csv",
-        download_as="dataframe",
-    )
-
-
-def get_ai_sample_patents() -> pd.DataFrame:
-    """From S3 loads dataframe of a sample of AI patents (random 10%)
-    with columns such as:
-        - application_number
-        - publication_number
-        - full list of cpc codes
-        - abstract_text
-        - publication_date
-        - inventor
-        - assignee
-    """
-    return download_obj(
-        AI_GENOMICS_BUCKET_NAME,
-        "inputs/patent_data/processed_patent_data/ai_sample_patents_cpc_codes.csv",
-        download_as="dataframe",
-    )
-
-
-def get_genomics_sample_patents() -> pd.DataFrame:
-    """From S3 loads dataframe of a sample of genomics patents (random 3%)
-    with columns such as:
-        - application_number
-        - publication_number
-        - full list of cpc codes
-        - abstract_text
-        - publication_date
-        - inventor
-        - assignee
-    """
-    return download_obj(
-        AI_GENOMICS_BUCKET_NAME,
-        "inputs/patent_data/processed_patent_data/genomics_sample_patents_cpc_codes.csv",
-        download_as="dataframe",
+    return pd.read_parquet(
+        f"s3://{BUCKET_NAME}/inputs/data_collection/patents/patents_clean.parquet"
     )
 
 

--- a/dap_aria_mapping/getters/patents.py
+++ b/dap_aria_mapping/getters/patents.py
@@ -15,8 +15,10 @@ def get_patents() -> pd.DataFrame:
     - inventor
     - assignee
     """
-    return pd.read_parquet(
-        f"s3://{BUCKET_NAME}/inputs/data_collection/patents/patents_clean.parquet"
+    return download_obj(
+        BUCKET_NAME,
+        "inputs/data_collection/patents/patents_clean.parquet",
+        download_as="dataframe",
     )
 
 

--- a/dap_aria_mapping/notebooks/patents_research.ipynb
+++ b/dap_aria_mapping/notebooks/patents_research.ipynb
@@ -1,0 +1,288 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "e8c1e65a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dap_aria_mapping.utils.conn import est_conn"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5aa1f119",
+   "metadata": {},
+   "source": [
+    "### 0. Establish bigquery connection "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "386caed3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "conn = est_conn()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5d45dad3",
+   "metadata": {},
+   "source": [
+    "### 1. How many patents there are where the INVENTOR is based in the UK and that were first filed within 2016 - 2021 inclusive?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5f2c4a42",
+   "metadata": {},
+   "source": [
+    "#### 1.1 NOT de-duplicating patents based on family id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "77083d7d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "there are 275458 patent documents of patents where the inventor is based in the UK and the patent was first filed between 2016 and 2021.\n"
+     ]
+    }
+   ],
+   "source": [
+    "q = \"select DISTINCT publication_number from `patents-public-data.patents.publications`, unnest(inventor_harmonized) as inventor where cast(filing_date as string) between '20160101' and '20211231' and inventor.country_code = 'GB'\"\n",
+    "query_job = conn.query(q)\n",
+    "results = query_job.result()  # Wait for query to complete.\n",
+    "print(f\"there are {results.total_rows} patent documents of patents where the inventor is based in the UK and the patent was first filed between 2016 and 2021.\") "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "758e73a9",
+   "metadata": {},
+   "source": [
+    "#### 1.2 de-duplicating patents based on family id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "d4dea27b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "there are 89375 patent documents of patent families where the inventor is based in the UK and the patent was first filed between 2016 and 2021.\n"
+     ]
+    }
+   ],
+   "source": [
+    "q = \"select DISTINCT family_id from `patents-public-data.patents.publications`, unnest(inventor_harmonized) as inventor, unnest(abstract_localized) as abstract where cast(filing_date as string) between '20160101' and '20211231' and inventor.country_code = 'GB' GROUP BY family_id\"\n",
+    "query_job = conn.query(q)\n",
+    "results = query_job.result()  # Wait for query to complete.\n",
+    "print(f\"there are {results.total_rows} patent documents of patent families where the inventor is based in the UK and the patent was first filed between 2016 and 2021.\") "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7e1931de",
+   "metadata": {},
+   "source": [
+    "#### 1.3 de-duplicating on family id AND language (abstract = english)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "ba2795b4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "there are 87964 patent documents of patent families where the inventor is based in the UK, the patent was first filed between 2016 and 2021 and there is at least one document in the family with an english language abstract.\n"
+     ]
+    }
+   ],
+   "source": [
+    "q = \"select DISTINCT family_id from `patents-public-data.patents.publications`, unnest(inventor_harmonized) as inventor, unnest(abstract_localized) as abstract where cast(filing_date as string) between '20160101' and '20211231' and inventor.country_code = 'GB' and abstract.language = 'en' GROUP BY family_id\"\n",
+    "query_job = conn.query(q)\n",
+    "results = query_job.result()  # Wait for query to complete.\n",
+    "print(f\"there are {results.total_rows} patent documents of patent families where the inventor is based in the UK, the patent was first filed between 2016 and 2021 and there is at least one document in the family with an english language abstract.\") "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9e0c4bc4",
+   "metadata": {},
+   "source": [
+    "### 2. How many patents there are where the ASSIGNEE is based in the UK and that were first filed within 2016 - 2021 inclusive?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ac7241bd",
+   "metadata": {},
+   "source": [
+    "#### 1.1 NOT de-duplicating patents based on family id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "b27fccc1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "there are 219645 patent documents of patents where the inventor is based in the UK and the patent was first filed between 2016 and 2021.\n"
+     ]
+    }
+   ],
+   "source": [
+    "q = \"select DISTINCT publication_number from `patents-public-data.patents.publications`, unnest(assignee_harmonized) as assignee where cast(filing_date as string) between '20160101' and '20211231' and assignee.country_code = 'GB'\"\n",
+    "query_job = conn.query(q)\n",
+    "results = query_job.result()  # Wait for query to complete.\n",
+    "print(f\"there are {results.total_rows} patent documents of patents where the inventor is based in the UK and the patent was first filed between 2016 and 2021.\") "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e15a9ef9",
+   "metadata": {},
+   "source": [
+    "#### 1.2 de-duplicating patents based on family id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c0ede520",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "q = \"select DISTINCT family_id from `patents-public-data.patents.publications`, unnest(assignee_harmonized) as assignee, unnest(abstract_localized) as abstract where cast(filing_date as string) between '20160101' and '20211231' and assignee.country_code = 'GB' GROUP BY family_id\"\n",
+    "query_job = conn.query(q)\n",
+    "results = query_job.result()  # Wait for query to complete.\n",
+    "print(f\"there are {results.total_rows} patent documents of patent families where the inventor is based in the UK and the patent was first filed between 2016 and 2021.\") "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8693cb5b",
+   "metadata": {},
+   "source": [
+    "#### 1.3 de-duplicating on family id AND language (abstract = english)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "48659687",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "q = \"select DISTINCT family_id from `patents-public-data.patents.publications`, unnest(assignee_harmonized) as assignee, unnest(abstract_localized) as abstract where cast(filing_date as string) between '20160101' and '20211231' and assignee.country_code = 'GB' and abstract.language = 'en' GROUP BY family_id\"\n",
+    "query_job = conn.query(q)\n",
+    "results = query_job.result()  # Wait for query to complete.\n",
+    "print(f\"there are {results.total_rows} patent documents of patent families where the inventor is based in the UK, the patent was first filed between 2016 and 2021 and there is at least one document in the family with an english language abstract.\") "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "55ce88db",
+   "metadata": {},
+   "source": [
+    "### 3. Can we generate the same sample using a random seed in bigquery?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "748e38fd",
+   "metadata": {},
+   "source": [
+    "No, it doesn't look like we can set a random seed in a bigquery query. Although if this is important, i think we can write standard sql and set a seed. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ead70a74",
+   "metadata": {},
+   "source": [
+    "### 4. Are there other tables that could be interesting?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "72c98609",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset_id = 'patents-public-data.patents'\n",
+    "tables = conn.list_tables(dataset_id)\n",
+    "\n",
+    "print(\"Tables contained in '{}':\".format(dataset_id))\n",
+    "for table in tables:\n",
+    "    print(\"{}.{}.{}\".format(table.project, table.dataset_id, table.table_id))\n",
+    "    \n",
+    "#looks like its just different versions of patent publications"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0ece2f12",
+   "metadata": {},
+   "source": [
+    "### 5. Are there rejected patents in google? "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "409ca988",
+   "metadata": {},
+   "source": [
+    "No, the data schema nor the bigquery results suggest that there are rejected patents in google bigquery."
+   ]
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "cell_metadata_filter": "-all",
+   "comment_magics": true
+  },
+  "kernelspec": {
+   "display_name": "dap_aria_mapping",
+   "language": "python",
+   "name": "dap_aria_mapping"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/dap_aria_mapping/pipeline/data_collection/patents.py
+++ b/dap_aria_mapping/pipeline/data_collection/patents.py
@@ -20,7 +20,7 @@ def patents_query(production=False) -> str:
         patents, deduplicated on family ID, of inventors based
         in the UK filed between 2016 and 2021.
 
-        If production is true, query for 10 publication numbers,
+        If production is false, query for 10 publication numbers,
             else query for all publication numbers.
 
     Returns query string.

--- a/dap_aria_mapping/pipeline/data_collection/patents.py
+++ b/dap_aria_mapping/pipeline/data_collection/patents.py
@@ -1,0 +1,77 @@
+"""
+patents pipeline
+--------------
+A pipeline that queries patents from Google Bigquery and
+saves patents results as a parquet file to s3.
+
+The pipeline collect all patents, deduplicated on family ID, of
+inventors based in the UK, filed between 2016 and 2021.
+
+python dap_aria_mapping/pipeline/data_collection/patents.py run
+
+NOTE: If the flow is in production, it will cost money to run this flow.
+Do NOT run this flow unless you have explicitly confirmed with Genna and India.
+"""
+from metaflow import FlowSpec, step, Parameter
+
+
+def patents_query(production=False) -> str:
+    """Generates patents query that collects information on
+        patents, deduplicated on family ID, of inventors based
+        in the UK filed between 2016 and 2021.
+
+        If production is true, query for 10 publication numbers,
+            else query for all publication numbers.
+
+    Returns query string.
+    """
+    filter_q = "select ANY_VALUE(publication_number) publication_number from `patents-public-data.patents.publications` , unnest(inventor_harmonized) as inventor, unnest(abstract_localized) as abstract where cast(filing_date as string) between '20160101' and '20211231' and inventor.country_code = 'GB' and abstract.language = 'en' GROUP BY family_id"
+    columns_q = "publication_number, application_number, country_code, family_id, title_localized, abstract_localized, publication_date, filing_date, grant_date, priority_date, cpc, inventor_harmonized, assignee_harmonized"
+    q = f"with filtered_ids as ({filter_q}) select {columns_q} from `patents-public-data.patents.publications` INNER JOIN filtered_ids USING(publication_number)"
+
+    if production:
+        return q
+    else:
+        return f"{q} LIMIT 10"
+
+
+class PatentsFlow(FlowSpec):
+    production = Parameter("production", help="Run in production?", default=True)
+
+    @step
+    def start(self):
+        """
+        Starts the flow.
+        """
+        self.next(self.retrieve_data)
+
+    @step
+    def retrieve_data(self):
+        """Retrieves relevant data from BigQuery"""
+        from dap_aria_mapping.utils.conn import est_conn
+
+        conn = est_conn()
+        patents_q = patents_query(production=self.production)
+        self.results = conn.query(patents_q).to_dataframe()
+        self.next(self.clean_data)
+
+    @step
+    def save_data(self):
+        """Saves data as parquet file to s3"""
+        from nesta_ds_utils.loading_saving.S3 import upload_obj
+        from dap_aria_mapping import BUCKET_NAME
+
+        upload_obj(
+            self.results, BUCKET_NAME, "inputs/data_collection/patents/patents.parquet"
+        )
+
+        self.next(self.end)
+
+    @step
+    def end(self):
+        """Ends the flow"""
+        pass
+
+
+if __name__ == "__main__":
+    PatentsFlow()

--- a/dap_aria_mapping/pipeline/data_collection/patents.py
+++ b/dap_aria_mapping/pipeline/data_collection/patents.py
@@ -36,7 +36,7 @@ def patents_query(production=False) -> str:
 
 
 class PatentsFlow(FlowSpec):
-    production = Parameter("production", help="Run in production?", default=True)
+    production = Parameter("production", help="Run in production?", default=False)
 
     @step
     def start(self):

--- a/dap_aria_mapping/pipeline/data_collection/patents.py
+++ b/dap_aria_mapping/pipeline/data_collection/patents.py
@@ -53,7 +53,7 @@ def patents_query(production=False) -> str:
 
 
 class PatentsFlow(FlowSpec):
-    production = Parameter("production", help="Run in production?", default=True)
+    production = Parameter("production", help="Run in production?", default=False)
 
     @step
     def start(self):
@@ -78,11 +78,14 @@ class PatentsFlow(FlowSpec):
         from nesta_ds_utils.loading_saving.S3 import upload_obj
         from dap_aria_mapping import BUCKET_NAME
 
-        upload_obj(
-            self.results,
-            BUCKET_NAME,
-            "inputs/data_collection/patents/patents_raw.parquet",
-        )
+        if self.production:
+            upload_obj(
+                self.results,
+                BUCKET_NAME,
+                "inputs/data_collection/patents/patents_raw.parquet",
+            )
+        else:
+            pass
 
         self.next(self.end)
 

--- a/dap_aria_mapping/pipeline/data_collection/processed_patents.py
+++ b/dap_aria_mapping/pipeline/data_collection/processed_patents.py
@@ -55,7 +55,11 @@ class PatentsProcessedFlow(FlowSpec):
         """
         Loads raw patents parquet file from S3
         """
-        self.patents = pd.read_parquet(f"s3://{BUCKET_NAME}/{self.raw_patents_path}")
+        from nesta_ds_utils.loading_saving.S3 import download_obj
+
+        self.patents = download_obj(
+            BUCKET_NAME, self.raw_patents_path, download_as="dataframe"
+        )
         self.next(self.convert_dates)
 
     @step
@@ -137,7 +141,7 @@ class PatentsProcessedFlow(FlowSpec):
         upload_obj(
             self.patents_lookup,
             BUCKET_NAME,
-            "inputs/data_collection/patents/patents_lookup.json",
+            "inputs/data_collection/patents/patents_for_annotation.json",
         )
 
         self.next(self.end)

--- a/dap_aria_mapping/pipeline/data_collection/processed_patents.py
+++ b/dap_aria_mapping/pipeline/data_collection/processed_patents.py
@@ -19,9 +19,6 @@ COLS_TO_UNNEST = ["inventor_harmonized", "assignee_harmonized"]
 def unnest_column(nested_col: str) -> Union[List[str], List[str]]:
     """Unnests country code and name from nested column
     of list of dictionaries with keys 'country_code' and 'name'
-
-    If country_code or name only contains 1 code or name,
-        return country_code or name string.
     """
     country_code = [col["country_code"] for col in nested_col]
     name = [col["name"] for col in nested_col]

--- a/dap_aria_mapping/pipeline/data_collection/processed_patents.py
+++ b/dap_aria_mapping/pipeline/data_collection/processed_patents.py
@@ -1,0 +1,126 @@
+"""
+process patents pipeline
+--------------
+A pipeline that processes fetched patents from Google Bigquery and
+saves processed patents results as a parquet file to s3.
+
+python dap_aria_mapping/pipeline/data_collection/processed_patents.py run
+"""
+import pandas as pd
+from typing import List, Union
+from metaflow import FlowSpec, step, Parameter
+from dap_aria_mapping import BUCKET_NAME
+
+DATE_COLS = ["publication_date", "filing_date", "grant_date", "priority_date"]
+TEXT_COLS = ["title_localized", "abstract_localized"]
+COLS_TO_UNNEST = ["inventor_harmonized", "assignee_harmonized"]
+
+
+def unnest_column(nested_col: str) -> Union[List[str], List[str]]:
+    """Unnests country code and name from nested column
+    of list of dictionaries with keys 'country_code' and 'name'
+
+    If country_code or name only contains 1 code or name,
+        return country_code or name string.
+    """
+    country_code = [col["country_code"] for col in nested_col]
+    name = [col["name"] for col in nested_col]
+
+    return country_code, name
+
+
+def extract_english_text(text_col: str) -> str:
+    """Extracts english text from text columns"""
+    for text in text_col:
+        if text["language"] == "en":
+            return text["text"]
+
+
+class PatentsProcessedFlow(FlowSpec):
+    production = Parameter("production", help="Run in production?", default=False)
+    raw_patents_path = Parameter(
+        "raw_patents_path",
+        help="s3 location of raw patents path",
+        default="inputs/data_collection/patents/patents_raw.parquet",
+    )
+
+    @step
+    def start(self):
+        """
+        Starts the flow.
+        """
+        self.next(self.load_data)
+
+    @step
+    def load_data(self):
+        """
+        Loads raw patents parquet file from S3
+        """
+        self.patents = pd.read_parquet(f"s3://{BUCKET_NAME}/{self.raw_patents_path}")
+        self.next(self.convert_dates)
+
+    @step
+    def convert_dates(self):
+        """
+        Converts all dates in patents data to '%Y%m%d' format
+        """
+        for date_col in DATE_COLS:
+            self.patents[date_col] = pd.to_datetime(
+                self.patents[date_col], format="%Y%m%d", errors="coerce"
+            )
+        self.next(self.clean_texts)
+
+    @step
+    def clean_texts(self):
+        """
+        Extracts english text in patents text columns
+        """
+        for text_col in TEXT_COLS:
+            self.patents[text_col] = self.patents[text_col].apply(extract_english_text)
+        self.next(self.unnest_columns)
+
+    @step
+    def unnest_columns(self):
+        """
+        Unnest columns with dictionaries that contain
+            'country code' and 'name' keys
+        """
+        for unnest_col in COLS_TO_UNNEST:
+            self.patents[unnest_col] = self.patents[unnest_col].apply(unnest_column)
+            (
+                self.patents[f"{unnest_col}_country_codes"],
+                self.patents[f"{unnest_col}_names"],
+            ) = zip(*self.patents[unnest_col])
+        self.next(self.extract_cpc_codes)
+
+    @step
+    def extract_cpc_codes(self):
+        """
+        Extract all CPC codes
+        """
+        self.patents["cpc"] = self.patents["cpc"].apply(
+            lambda x: [c["code"] for c in x]
+        )
+        self.next(self.save_data)
+
+    @step
+    def save_data(self):
+        """Saves clean patents data as parquet file to s3"""
+        from nesta_ds_utils.loading_saving.S3 import upload_obj
+
+        upload_obj(
+            self.patents,
+            BUCKET_NAME,
+            "inputs/data_collection/patents/patents_clean.parquet",
+        )
+
+        self.next(self.end)
+
+    @step
+    def end(self):
+        """Ends the flow"""
+        pass
+
+
+if __name__ == "__main__":
+    PatentsProcessedFlow()

--- a/dap_aria_mapping/pipeline/data_collection/tests/test_patents.py
+++ b/dap_aria_mapping/pipeline/data_collection/tests/test_patents.py
@@ -1,0 +1,26 @@
+"""
+Tests that the final patents dataset is filtered appropriately based
+    on the filing date being between 2016 - 2021 and that at least
+    one inventor is based in GB.
+
+pytest dap_aria_mapping/pipeline/data_collection/tests/test_patents.py
+"""
+import pytest
+from dap_aria_mapping.getters.patents import get_patents
+
+patents_sample = get_patents().sample(50)
+
+
+def test_patents():
+    # make sure the filing date is between 2016-01-01 and 2021-12-31
+    assert (
+        (patents_sample["filing_date"] < "2021-12-31")
+        & (patents_sample["filing_date"] > "2016-01-01")
+    ).all() == True
+    # make sure at least one inventor is from the UK
+    assert (
+        patents_sample["inventor_harmonized_country_codes"]
+        .apply(lambda x: True if "GB" in x else False)
+        .all()
+        == True
+    )

--- a/dap_aria_mapping/pipeline/data_collection/tests/test_patents.py
+++ b/dap_aria_mapping/pipeline/data_collection/tests/test_patents.py
@@ -12,6 +12,14 @@ patents_sample = get_patents().sample(50)
 
 
 def test_patents():
+    # make sure every publication number is unique
+    assert (
+        len(patents_sample) == len(patents_sample["publication_number"].unique())
+    ) == True
+
+    # make sure every family id is unique as we should only have one patent document number per family id
+    assert (len(patents_sample) == len(patents_sample["family_id"].unique())) == True
+
     # make sure the filing date is between 2016-01-01 and 2021-12-31
     assert (
         (patents_sample["filing_date"] < "2021-12-31")

--- a/dap_aria_mapping/pipeline/data_collection/tests/test_processed_patents.py
+++ b/dap_aria_mapping/pipeline/data_collection/tests/test_processed_patents.py
@@ -1,0 +1,57 @@
+"""
+Tests cleaning steps for raw patents data.
+
+pytest dap_aria_mapping/pipeline/data_collection/tests/test_processed_patents.py
+"""
+
+import pytest
+
+from dap_aria_mapping.pipeline.data_collection.processed_patents import (
+    unnest_column,
+    extract_english_text,
+)
+from dap_aria_mapping import BUCKET_NAME
+import pandas as pd
+
+raw_patents_path = "inputs/data_collection/patents/patents_raw.parquet"
+patents_sample = pd.read_parquet(f"s3://{BUCKET_NAME}/{raw_patents_path}").sample(50)
+
+
+def test_unnest_column():
+
+    assert "inventor_harmonized" in patents_sample.columns
+    assert "assignee_harmonized" in patents_sample.columns
+
+    patents_sample["inventor_harmonized"] = patents_sample["inventor_harmonized"].apply(
+        unnest_column
+    )
+    patents_sample["assignee_harmonized"] = patents_sample["assignee_harmonized"].apply(
+        unnest_column
+    )
+
+    assert type(patents_sample["inventor_harmonized"].iloc[0]) == tuple
+    assert type(patents_sample["assignee_harmonized"].iloc[0]) == tuple
+
+    assert type(patents_sample["inventor_harmonized"].iloc[0][0]) == list
+    assert type(patents_sample["assignee_harmonized"].iloc[0][1]) == list
+
+    # based on querying, at least one inventor must have 'GB' associated to them
+    assert "GB" in patents_sample["inventor_harmonized"].iloc[1][0]
+
+
+def test_extract_english_text():
+    assert "title_localized" in patents_sample.columns
+    assert "abstract_localized" in patents_sample.columns
+
+    patents_sample["title_localized"] = patents_sample["title_localized"].apply(
+        extract_english_text
+    )
+    patents_sample["abstract_localized"] = patents_sample["abstract_localized"].apply(
+        extract_english_text
+    )
+
+    # based on querying, no abstract should be nan
+    assert len(patents_sample[patents_sample["abstract_localized"].isna()]) == 0
+
+    assert type(patents_sample["title_localized"].iloc[0]) == str
+    assert type(patents_sample["abstract_localized"].iloc[0]) == str

--- a/dap_aria_mapping/utils/conn.py
+++ b/dap_aria_mapping/utils/conn.py
@@ -1,0 +1,36 @@
+from google.oauth2.service_account import Credentials
+from google.cloud import bigquery
+
+from dap_aria_mapping import PROJECT_DIR, BUCKET_NAME, logger
+from nesta_ds_utils.loading_saving.S3 import download_file
+import os
+
+
+def est_conn() -> bigquery.Client:
+    """Instantiate Google BigQuery client to query data.
+
+    Assumes service account key is saved as
+        PROJECT_DIR/credentials/patents-key.json. If credentials
+        path not set in your global environment, set credentials
+        path. If credentials file not saved locally, download
+        credentials json locally then set path.
+
+    Returns instantiated bigquery client with passed credentials.
+    """
+    google_creds = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+    credentials_file = PROJECT_DIR / "credentials/patents-key.json"
+
+    if not google_creds:
+        if not credentials_file.is_file():
+            logger.info("credentials file not saved locally, downloading file...")
+            download_file(
+                path_from="credentials/patents-key.json",
+                bucket=BUCKET_NAME,
+                path_to=str(credentials_file),
+            )
+        os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = str(credentials_file)
+
+    credentials = Credentials.from_service_account_file(credentials_file)
+    client = bigquery.Client(credentials=credentials)
+
+    return client

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 pandas
 git+https://github.com/nestauk/nesta_ds_utils.git
+google-cloud-bigquery==3.4.0
+google-cloud-bigquery-storage==2.16.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
-pandas
+pandas==1.5.1
 git+https://github.com/nestauk/nesta_ds_utils.git
+metaflow==2.7.14
 google-cloud-bigquery==3.4.0
 google-cloud-bigquery-storage==2.16.2
+db-dtypes


### PR DESCRIPTION
---

# Description

This PR contains:
1) An initial analysis of the # of patents in google bigquery between 2016-2021 where at least one inventor is from the UK;
2) The full, initial patents pipeline of querying google bigquery for patents data, cleaning it and saving it to s3. 

This PR closes:
#19 
#3 
#4 

# Instructions for Reviewer

To pull data from google bigquery:

`python dap_aria_mapping/pipeline/data_collection/patents.py run
`

**BEWARE!!!** If production=true, this will cost money! I accidentally charged myself £5.36 for the full dataset. I've since changed cards to be nesta's business card but lets not run it in production unless it feels like we've got to re-collect data.

To post process the data:

`python dap_aria_mapping/pipeline/data_collection/processed_patents.py run
`

This reformats all the date columns, extracts english titles and abstracts and unnests the assignee and inventor to be in a list of strings format instead of a list of dict format. 

It also creates a look up table sam will need to extract entities.

In order to test the code in this PR you need to ...

`pytest dap_aria_mapping/pipeline/data_collection/tests/test_patents.py
`

To make sure that the clean patents dataset:
- Has a unique publication_number AND family_id per row;
- Each patent document's filing date is between 01-01-2016 and 31-12-2021;
- Has at least 1 inventor based in the UK associated to the invention 

`pytest dap_aria_mapping/pipeline/data_collection/tests/test_processed_patents.py
`
To test the unnest_column and extract_english_text processing functions 

Please pay special attention to ...

running `python dap_aria_mapping/pipeline/data_collection/patents.py run` in production - it will cost money! 

# Checklist:

- [ ] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [x] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [x] I have documented the code
  - [x] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [x] I have explained this PR above
- [x] I have requested a code review
