### PR TITLE
[5] Reformat Entities pipeline

### DIFF
--- a/dap_aria_mapping/getters/openalex.py
+++ b/dap_aria_mapping/getters/openalex.py
@@ -70,6 +70,18 @@ def get_openalex_citations() -> Dict:
     )
 
 
+def get_openalex_entities() -> Mapping[str, Mapping[str, Union[str, str]]]:
+    """From S3 loads openalex entities"""
+    return download_obj(
+        BUCKET_NAME,
+        "inputs/data_collection/processed_openalex/preprocessed_annotated_abstracts.json",
+        download_as="dict",
+    )
+
+
+#########TEMPORARY AI GENOMICS GETTERS##########################
+
+
 def get_openalex_ai_genomics_works() -> pd.DataFrame:
     """Returns dataframe of AI in genomics OpenAlex works. Abstracts are NOT included.
     Works data includes:
@@ -147,15 +159,6 @@ def get_openalex_genomics_abstracts() -> Dict[str, str]:
     return download_obj(
         AI_GENOMICS_BUCKET_NAME,
         "outputs/openalex/genomics_openalex_abstracts.json",
-        download_as="dict",
-    )
-
-
-def get_openalex_entities() -> Mapping[str, Mapping[str, Union[str, str]]]:
-    """From S3 loads post-processed openalex DBpedia entities"""
-    return download_obj(
-        AI_GENOMICS_BUCKET_NAME,
-        "outputs/entity_extraction/oa_lookup_clean.json",
         download_as="dict",
     )
 

--- a/dap_aria_mapping/getters/patents.py
+++ b/dap_aria_mapping/getters/patents.py
@@ -22,6 +22,18 @@ def get_patents() -> pd.DataFrame:
     )
 
 
+def get_patent_entities() -> Mapping[str, Mapping[str, Union[str, str]]]:
+    """From S3 loads patent entities"""
+    return download_obj(
+        BUCKET_NAME,
+        "inputs/data_collection/patents/preprocessed_annotated_patents.json",
+        download_as="dict",
+    )
+
+
+#########TEMPORARY AI GENOMICS GETTERS##########################
+
+
 def get_ai_genomics_patents_entities() -> Mapping[str, Mapping[str, Union[str, str]]]:
     """From S3 loads post-processed AI in genomics patents DBpedia entities"""
     return download_obj(

--- a/dap_aria_mapping/pipeline/entity_processing/reformat_entities.py
+++ b/dap_aria_mapping/pipeline/entity_processing/reformat_entities.py
@@ -1,0 +1,87 @@
+from typing import Dict
+import boto3
+import json
+
+from metaflow import FlowSpec, step, Parameter, batch
+
+
+PATENT_ANNOTATION_OUTPUT = "inputs/data_collection/patents/preprocessed_annotated_patents.json"
+OPENALEX_ANNOTATION_OUTPUT = "inputs/data_collection/processed_openalex/preprocessed_annotated_abstracts.json"
+INPUTS = [
+    "inputs/data_collection/patents/annotated_patents.json",
+    "inputs/data_collection/processed_openalex/annotated_abstracts.json"
+]
+
+
+def reformat_dictionary(dictionary: Dict) -> Dict:
+    """
+    Cleans out the unnecessary information from the annotation output dictionary
+    """
+    if "dbpedia_entities" in dictionary.keys():
+        dictionary["dbpedia_entities"] = [
+            {
+                "confidence": entity["confidence"],
+                "URI": entity["URI"],
+            }
+            for entity in dictionary["dbpedia_entities"]
+            if entity["confidence"] > 40
+        ]
+        return {
+            "id": dictionary["id"],
+            "dbpedia_entities": dictionary["dbpedia_entities"]
+        }
+    else:
+        return {
+            "id": dictionary["id"],
+            "dbpedia_entities": []
+        }
+
+
+class EntityReformattingFlow(FlowSpec):
+    production = Parameter("production", help="Run in production?", default=False)
+    @step
+    def start(self):
+        """
+        Starts the flow.
+        """
+        if self.production:
+            self.input_files = INPUTS
+        else:
+            self.input_files = INPUTS[:1]
+        self.next(self.reformat_entities, foreach="input_files")
+
+    @batch(cpu=2, memory=64000)
+    @step
+    def reformat_entities(self):
+        """
+        Reformat the entities dictionary to remove unnecessary information.
+        """
+        s3 = boto3.resource("s3")
+        content_object = s3.Object("aria-mapping", self.input)
+        file_content = content_object.get()['Body'].read().decode("utf-8")
+        json_content = json.loads(file_content)
+        reformatted_entities = [
+            reformat_dictionary(item)
+            for item in json_content
+        ]
+        if "annotated_patents.json" in self.input:
+            s3object = s3.Object("aria-mapping", PATENT_ANNOTATION_OUTPUT)
+        else:
+            s3object = s3.Object("aria-mapping", OPENALEX_ANNOTATION_OUTPUT)
+        s3object.put(
+            Body=(bytes(json.dumps(reformatted_entities).encode("UTF-8")))
+        )
+        self.next(self.dummy_join)
+
+    @step
+    def dummy_join(self, inputs):
+        """Dummy join step"""
+        self.next(self.end)
+
+    @step
+    def end(self):
+        """Ends the flow"""
+        pass
+
+if __name__ == "__main__":
+    EntityReformattingFlow()

--- a/dap_aria_mapping/pipeline/entity_processing/reformat_entities_requirements.txt
+++ b/dap_aria_mapping/pipeline/entity_processing/reformat_entities_requirements.txt
@@ -1,0 +1,3 @@
+pandas
+fsspec
+s3fs

--- a/dap_aria_mapping/pipeline/entity_processing/tests/test_reformat_entities.py
+++ b/dap_aria_mapping/pipeline/entity_processing/tests/test_reformat_entities.py
@@ -1,95 +1,47 @@
 import pytest
+import numpy as np
 
 from dap_aria_mapping.pipeline.entity_processing.reformat_entities import (
     reformat_dictionary
 )
 
 
-EXAMPLE_DICT_A = {
-    "id": "US-9726461-B2",
-    "abstract": "A terrain disruption device"
+EXAMPLE_INPUT = {
+    "a":[],
+    "b": [
+        {
+            "URI": "http://dpbedia.org/resource/Heat",
+            "confidence": 70
+        },
+        {
+            "URI": "http://dpbedia.org/resource/Energy_consumption",
+            "confidence": 80
+        }
+    ],
+    "c": [
+        {
+            "URI": "http://dpbedia.org/resource/Heat",
+            "confidence": 40
+        },
+        {
+            "URI": "http://dpbedia.org/resource/Energy_consumption",
+            "confidence": 40
+        }
+    ]
 }
 
-EXAMPLE_DICT_B = {
-    'id': 'US-9792517-B2',
-    'abstract': 'A computer-implemented method ',
-    'dbpedia_entities': [
-        {'confidence': 70, 'URI': 'vector graphics'},
-        {'confidence': 60, 'URI': 'stroke'},
-        {'confidence': 70, 'URI': 'pointing device'},
-        {'confidence': 80, 'URI': 'real-time computer graphics'}],
-    'dbpedia_entities_metadata': {
-        'dupes_10_count': 8,
-        'dupes_60_count': 2,
-        'entities_count': 30,
-        'confidence_counts': {
-            '20': 1,
-            '30': 24,
-            '40': 1,
-            '60': 1,
-            '70': 2,
-            '80': 1},
-        'confidence_max': 80,
-        'dupes_10_ratio': 0.26666666666666666,
-        'dupes_60_ratio': 0.06666666666666667,
-        'confidence_avg': 35.333333333333336,
-        'confidence_min': 20}
-    }
-
-
-EXAMPLE_DICT_C = {
-    'id': 'US-9792517-B2',
-    'abstract': 'A computer-implemented method ',
-    'dbpedia_entities': [
-        {'confidence': 20, 'URI': 'vector graphics'},
-        {'confidence': 20, 'URI': 'stroke'},
-        {'confidence': 20, 'URI': 'pointing device'},
-        {'confidence': 20, 'URI': 'real-time computer graphics'}],
-    'dbpedia_entities_metadata': {
-        'dupes_10_count': 8,
-        'dupes_60_count': 2,
-        'entities_count': 30,
-        'confidence_counts': {
-            '20': 1,
-            '30': 24,
-            '40': 1,
-            '60': 1,
-            '70': 2,
-            '80': 1},
-        'confidence_max': 80,
-        'dupes_10_ratio': 0.26666666666666666,
-        'dupes_60_ratio': 0.06666666666666667,
-        'confidence_avg': 35.333333333333336,
-        'confidence_min': 20}
-    }
-
 def test_reformat_dictionary():
-    assert reformat_dictionary(EXAMPLE_DICT_A) == {
-        "id": "US-9726461-B2",
-        "dbpedia_entities": []
-    }
-    assert reformat_dictionary(EXAMPLE_DICT_B) == {
-        "id": "US-9792517-B2",
-        "dbpedia_entities": [
+    assert reformat_dictionary(EXAMPLE_INPUT) == {
+        "a": [],
+        "b": [
             {
-                "confidence": 70,
-                "URI": "vector graphics"
+                "entity": "Heat",
+                "confidence": 70
             },
             {
-                "confidence": 60,
-                "URI": "stroke"
-            },
-            {
-                "confidence": 70,
-                "URI": "pointing device"
-            },
-            {
-                "confidence": 80,
-                "URI": "real-time computer graphics"
+                "entity": "Energy consumption",
+                "confidence": 80
             }
-        ]
-    }
-    assert reformat_dictionary(EXAMPLE_DICT_C) == {
-        "id": "US-9792517-B2",
-        "dbpedia_entities": []
+        ],
+        "c": []
     }

--- a/dap_aria_mapping/pipeline/entity_processing/tests/test_reformat_entities.py
+++ b/dap_aria_mapping/pipeline/entity_processing/tests/test_reformat_entities.py
@@ -1,0 +1,95 @@
+import pytest
+
+from dap_aria_mapping.pipeline.entity_processing.reformat_entities import (
+    reformat_dictionary
+)
+
+
+EXAMPLE_DICT_A = {
+    "id": "US-9726461-B2",
+    "abstract": "A terrain disruption device"
+}
+
+EXAMPLE_DICT_B = {
+    'id': 'US-9792517-B2',
+    'abstract': 'A computer-implemented method ',
+    'dbpedia_entities': [
+        {'confidence': 70, 'URI': 'vector graphics'},
+        {'confidence': 60, 'URI': 'stroke'},
+        {'confidence': 70, 'URI': 'pointing device'},
+        {'confidence': 80, 'URI': 'real-time computer graphics'}],
+    'dbpedia_entities_metadata': {
+        'dupes_10_count': 8,
+        'dupes_60_count': 2,
+        'entities_count': 30,
+        'confidence_counts': {
+            '20': 1,
+            '30': 24,
+            '40': 1,
+            '60': 1,
+            '70': 2,
+            '80': 1},
+        'confidence_max': 80,
+        'dupes_10_ratio': 0.26666666666666666,
+        'dupes_60_ratio': 0.06666666666666667,
+        'confidence_avg': 35.333333333333336,
+        'confidence_min': 20}
+    }
+
+
+EXAMPLE_DICT_C = {
+    'id': 'US-9792517-B2',
+    'abstract': 'A computer-implemented method ',
+    'dbpedia_entities': [
+        {'confidence': 20, 'URI': 'vector graphics'},
+        {'confidence': 20, 'URI': 'stroke'},
+        {'confidence': 20, 'URI': 'pointing device'},
+        {'confidence': 20, 'URI': 'real-time computer graphics'}],
+    'dbpedia_entities_metadata': {
+        'dupes_10_count': 8,
+        'dupes_60_count': 2,
+        'entities_count': 30,
+        'confidence_counts': {
+            '20': 1,
+            '30': 24,
+            '40': 1,
+            '60': 1,
+            '70': 2,
+            '80': 1},
+        'confidence_max': 80,
+        'dupes_10_ratio': 0.26666666666666666,
+        'dupes_60_ratio': 0.06666666666666667,
+        'confidence_avg': 35.333333333333336,
+        'confidence_min': 20}
+    }
+
+def test_reformat_dictionary():
+    assert reformat_dictionary(EXAMPLE_DICT_A) == {
+        "id": "US-9726461-B2",
+        "dbpedia_entities": []
+    }
+    assert reformat_dictionary(EXAMPLE_DICT_B) == {
+        "id": "US-9792517-B2",
+        "dbpedia_entities": [
+            {
+                "confidence": 70,
+                "URI": "vector graphics"
+            },
+            {
+                "confidence": 60,
+                "URI": "stroke"
+            },
+            {
+                "confidence": 70,
+                "URI": "pointing device"
+            },
+            {
+                "confidence": 80,
+                "URI": "real-time computer graphics"
+            }
+        ]
+    }
+    assert reformat_dictionary(EXAMPLE_DICT_C) == {
+        "id": "US-9792517-B2",
+        "dbpedia_entities": []
+    }


### PR DESCRIPTION
---

# Description

Adds the pipeline to strip out the unnecessary variables from the annotated patents/publications.
Includes test for added functions.
I purposefully haven't included getters as I'm not sure these files are useful for analysis (but the post processed files will)

# Instructions for Reviewer

Run `python dap_aria_mapping/pipeline/entity_processing/reformat_entities.py --datastore=s3 run` to run the flow in test mode
Run pytest on the test file

# Checklist:

- [x] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [x] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [x] I have documented the code
  - [x] Major functions have docstrings
  - [x] Appropriate information has been added to `README`s
- [x] I have explained this PR above
- [x] I have requested a code review

THE ONLY CHANGED FILES ARE `dap_aria_mapping/pipeline/entity_processing/reformat_entities.py` AND `dap_aria_mapping/pipeline/entity_processing/tests/test_reformat_entities.py`