### PR TITLE
[27] disambiguate assignees

### DIFF
--- a/dap_aria_mapping/pipeline/data_collection/processed_patents.py
+++ b/dap_aria_mapping/pipeline/data_collection/processed_patents.py
@@ -18,9 +18,6 @@ DATE_COLS = ["publication_date", "filing_date", "grant_date", "priority_date"]
 TEXT_COLS = ["title_localized", "abstract_localized"]
 COLS_TO_UNNEST = ["inventor_harmonized", "assignee_harmonized"]
 
-INVENTORS = ["JOHN DOE", "MARY JANE", "JACK VINES"]
-ASSIGNEES = ["JACK VINES", "UNIV WASHINGTON"]
-
 
 def unnest_column(nested_col: str) -> Union[List[str], List[str]]:
     """Unnests country code and name from nested column

--- a/dap_aria_mapping/pipeline/data_collection/tests/test_processed_patents.py
+++ b/dap_aria_mapping/pipeline/data_collection/tests/test_processed_patents.py
@@ -9,12 +9,16 @@ import pytest
 from dap_aria_mapping.pipeline.data_collection.processed_patents import (
     unnest_column,
     extract_english_text,
+    disambiguate_assignee,
 )
 from dap_aria_mapping import BUCKET_NAME
 import pandas as pd
 
 raw_patents_path = "inputs/data_collection/patents/patents_raw.parquet"
 patents_sample = pd.read_parquet(f"s3://{BUCKET_NAME}/{raw_patents_path}").sample(50)
+
+INVENTORS = ["JOHN DOE", "MARY JANE", "JACK VINES"]
+ASSIGNEES = ["JACK VINES", "UNIV WASHINGTON"]
 
 
 def test_unnest_column():
@@ -55,3 +59,9 @@ def test_extract_english_text():
 
     assert type(patents_sample["title_localized"].iloc[0]) == str
     assert type(patents_sample["abstract_localized"].iloc[0]) == str
+
+
+def test_disambiguate_assignee():
+    assignee_type = disambiguate_assignee(INVENTORS, ASSIGNEES)
+    assert len(assignee_type) == len(ASSIGNEES)
+    assert assignee_type == ["PERSON", "ORGANISATION"]


### PR DESCRIPTION
---

# Description

Teeny weeny PR to disambiguate assignees by labelling assignees as 'PERSON' or 'ORGANIZATION' depending on whether the assignee is also an inventor 

Fixes # (issue)

closes #27  

# Instructions for Reviewer

In order to test the code in this PR you need to ...

`python dap_aria_mapping/pipeline/data_collection/processed_patents.py run`

`pytest dap_aria_mapping/pipeline/data_collection/tests/test_processed_patents.py`

Please pay special attention to ...

# Checklist:

- [x] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [x] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [x] I have documented the code
  - [x] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [x] I have explained this PR above
- [x] I have requested a code review
