### PR TITLE
55 docs with topics

### DIFF
--- a/dap_aria_mapping/getters/openalex.py
+++ b/dap_aria_mapping/getters/openalex.py
@@ -78,6 +78,27 @@ def get_openalex_entities() -> Mapping[str, Mapping[str, Union[str, str]]]:
         download_as="dict",
     )
 
+def get_openalex_topics(tax: str = 'cooccur', level: int = 1) -> Dict:
+    """gets openalex document ids tagged with topics from the specified taxonomy
+    at a given level"
+
+    Args:
+        tax (str, optional): taxonomy labels to use. Defaults to 'cooccur'.
+            PIPELINE HAS CURRENTLY ONLY BEEN RUN FOR COOCURRENCE SO THIS IS THE ONLY OPTION
+        level (int, optional): level of the taxonomy to use. Defaults to 1.
+            options are 1, 2, 3, 4, 5.
+
+    Returns:
+        Dict: dictionary with document ids tagged with topic labels of the taxonomy.
+            key: openalex id, value: list of topic labels. Labels are formatted as
+            [LEVEL 1 LABEL]-[LEVEL 2 LABEL]-[ETC]
+    """
+
+    return download_obj(
+        BUCKET_NAME,
+        "outputs/docs_with_topics/{}/openalex/Level_{}.json".format(tax,str(level)),
+        download_as="dict",
+    )
 
 #########TEMPORARY AI GENOMICS GETTERS##########################
 

--- a/dap_aria_mapping/getters/openalex.py
+++ b/dap_aria_mapping/getters/openalex.py
@@ -12,7 +12,7 @@ note:
 """
 import pandas as pd
 from nesta_ds_utils.loading_saving.S3 import download_obj
-from typing import Mapping, Union, Dict
+from typing import Mapping, Union, Dict, List
 from dap_aria_mapping import AI_GENOMICS_BUCKET_NAME, BUCKET_NAME
 
 
@@ -78,7 +78,7 @@ def get_openalex_entities() -> Mapping[str, Mapping[str, Union[str, str]]]:
         download_as="dict",
     )
 
-def get_openalex_topics(tax: str = 'cooccur', level: int = 1) -> Dict:
+def get_openalex_topics(tax: str = 'cooccur', level: int = 1) -> Dict[str, List[str]]:
     """gets openalex document ids tagged with topics from the specified taxonomy
     at a given level"
 
@@ -90,7 +90,7 @@ def get_openalex_topics(tax: str = 'cooccur', level: int = 1) -> Dict:
 
     Returns:
         Dict: dictionary with document ids tagged with topic labels of the taxonomy.
-            key: openalex id, value: list of topic labels. Labels are formatted as
+            key: {document id: [topic label, topic label, etc.]} where labels are formatted as:
             [LEVEL 1 LABEL]-[LEVEL 2 LABEL]-[ETC]
     """
 

--- a/dap_aria_mapping/getters/openalex.py
+++ b/dap_aria_mapping/getters/openalex.py
@@ -80,7 +80,7 @@ def get_openalex_entities() -> Mapping[str, Mapping[str, Union[str, str]]]:
 
 def get_openalex_topics(tax: str = 'cooccur', level: int = 1) -> Dict[str, List[str]]:
     """gets openalex document ids tagged with topics from the specified taxonomy
-    at a given level"
+    at a given level
 
     Args:
         tax (str, optional): taxonomy labels to use. Defaults to 'cooccur'.

--- a/dap_aria_mapping/getters/patents.py
+++ b/dap_aria_mapping/getters/patents.py
@@ -1,7 +1,7 @@
 import pandas as pd
 from nesta_ds_utils.loading_saving.S3 import download_obj
 from dap_aria_mapping import BUCKET_NAME, AI_GENOMICS_BUCKET_NAME
-from typing import Mapping, Union, Dict
+from typing import Mapping, Union, Dict, List
 import pandas as pd
 
 
@@ -30,7 +30,7 @@ def get_patent_entities() -> Mapping[str, Mapping[str, Union[str, str]]]:
         download_as="dict",
     )
 
-def get_patent_topics(tax: str = 'cooccur', level: int = 1) -> Dict:
+def get_patent_topics(tax: str = 'cooccur', level: int = 1) -> Dict[str, List[str]]:
     """gets patent ids tagged with topics from the specified taxonomy
     at a given level"
 
@@ -41,8 +41,8 @@ def get_patent_topics(tax: str = 'cooccur', level: int = 1) -> Dict:
             options are 1, 2, 3, 4, 5.
 
     Returns:
-        Dict: dictionary with document ids tagged with topic labels of the taxonomy.
-            key: patent id, value: list of topic labels. Labels are formatted as
+        Dict: dictionary with patent ids tagged with topic labels of the taxonomy.
+            key: {patent id: [topic label, topic label, etc.]} where labels are formatted as:
             [LEVEL 1 LABEL]-[LEVEL 2 LABEL]-[ETC]
     """
 

--- a/dap_aria_mapping/getters/patents.py
+++ b/dap_aria_mapping/getters/patents.py
@@ -1,7 +1,7 @@
 import pandas as pd
 from nesta_ds_utils.loading_saving.S3 import download_obj
 from dap_aria_mapping import BUCKET_NAME, AI_GENOMICS_BUCKET_NAME
-from typing import Mapping, Union
+from typing import Mapping, Union, Dict
 import pandas as pd
 
 
@@ -27,6 +27,28 @@ def get_patent_entities() -> Mapping[str, Mapping[str, Union[str, str]]]:
     return download_obj(
         BUCKET_NAME,
         "inputs/data_collection/patents/preprocessed_annotated_patents.json",
+        download_as="dict",
+    )
+
+def get_patent_topics(tax: str = 'cooccur', level: int = 1) -> Dict:
+    """gets patent ids tagged with topics from the specified taxonomy
+    at a given level"
+
+    Args:
+        tax (str, optional): taxonomy labels to use. Defaults to 'cooccur'.
+            PIPELINE HAS CURRENTLY ONLY BEEN RUN FOR COOCURRENCE SO THIS IS THE ONLY OPTION
+        level (int, optional): level of the taxonomy to use. Defaults to 1.
+            options are 1, 2, 3, 4, 5.
+
+    Returns:
+        Dict: dictionary with document ids tagged with topic labels of the taxonomy.
+            key: patent id, value: list of topic labels. Labels are formatted as
+            [LEVEL 1 LABEL]-[LEVEL 2 LABEL]-[ETC]
+    """
+
+    return download_obj(
+        BUCKET_NAME,
+        "outputs/docs_with_topics/{}/patents/Level_{}.json".format(tax,str(level)),
         download_as="dict",
     )
 

--- a/dap_aria_mapping/getters/patents.py
+++ b/dap_aria_mapping/getters/patents.py
@@ -32,7 +32,7 @@ def get_patent_entities() -> Mapping[str, Mapping[str, Union[str, str]]]:
 
 def get_patent_topics(tax: str = 'cooccur', level: int = 1) -> Dict[str, List[str]]:
     """gets patent ids tagged with topics from the specified taxonomy
-    at a given level"
+    at a given level
 
     Args:
         tax (str, optional): taxonomy labels to use. Defaults to 'cooccur'.

--- a/dap_aria_mapping/getters/taxonomies.py
+++ b/dap_aria_mapping/getters/taxonomies.py
@@ -64,7 +64,7 @@ def get_cooccurrence_taxonomy() -> pd.DataFrame:
     """
     return download_obj(
         BUCKET_NAME,
-        "outputs/community_detection_clusters.parquet",
+        "outputs/community_detection_taxonomy/tax.parquet",
         download_as="dataframe",
     )
 
@@ -82,7 +82,7 @@ def get_test_cooccurrence_taxonomy() -> pd.DataFrame:
     """
     return download_obj(
         BUCKET_NAME,
-        "outputs/test_community_detection_clusters.parquet",
+        "outputs/community_detection_taxonomy/test.parquet",
         download_as="dataframe",
     )
 

--- a/dap_aria_mapping/pipeline/label_docs_with_taxonomy.py
+++ b/dap_aria_mapping/pipeline/label_docs_with_taxonomy.py
@@ -8,16 +8,17 @@ import pandas as pd
 import json
 import argparse
 from dap_aria_mapping import logger
+from typing import Dict, List, Mapping, Union
 
-def tag_docs_at_level(docs: dict, tax_at_level: pd.Series) -> dict:
+def tag_docs_at_level(docs: Mapping[str, Mapping[str, Union[str, str]]], tax_at_level: pd.Series) -> Dict[str, List[str]]:
     """tag documents with topic labels based on entities present in document
 
     Args:
-        docs (dict): dictionary where key: document id, value: list of entity information about each document
+        docs (Mapping): mapping of entity information to document ids
         tax_at_level (pd.Series): taxonomy of entities, index: entity, value: topic of entity at a given level of the taxonomy
 
     Returns:
-        dict: key: documentid, value: list of topics per document at given level of taxonomy 
+        Dict: {document id: [topic label, topic label, etc.]}
     """
     topics_per_doc = defaultdict()
     for docid, entity_list in docs.items():

--- a/dap_aria_mapping/pipeline/label_docs_with_taxonomy.py
+++ b/dap_aria_mapping/pipeline/label_docs_with_taxonomy.py
@@ -7,6 +7,7 @@ from nesta_ds_utils.loading_saving.S3 import upload_obj
 import pandas as pd
 import json
 import argparse
+from dap_aria_mapping import logger
 
 def tag_docs_at_level(docs: dict, tax_at_level: pd.Series) -> dict:
     """tag documents with topic labels based on entities present in document
@@ -54,7 +55,7 @@ if __name__ == '__main__':
     
 
     args = parser.parse_args()
-    print("loading taxonomy")
+    logger.info("loading taxonomy")
     if args.taxonomy == 'cooccur':
         taxonomy = get_cooccurrence_taxonomy()
     elif args.taxonomy == 'centroids':
@@ -62,13 +63,13 @@ if __name__ == '__main__':
     elif args.taxonomy == 'imbalanced':
         taxonomy = get_semantic_taxonomy(cluster_object='imbalanced')
     else:
-        print("INVALID TAXONOMY")
+        logger.info("INVALID TAXONOMY")
     
-    print("TAGGING PATENTS WITH TOPICS")
-    print("loading patents data")
+    logger.info("TAGGING PATENTS WITH TOPICS")
+    logger.info("loading patents data")
     patents = get_patent_entities()
     for level in range(1,len(taxonomy.columns)+1):
-        print("starting tagging for level {}".format(level))
+        logger.info("starting tagging for level {}".format(level))
         tax_at_level = taxonomy["Level_{}".format(level)]
         topics_per_doc = tag_docs_at_level(patents, tax_at_level)
         if args.local:
@@ -82,11 +83,11 @@ if __name__ == '__main__':
             )
         
 
-    print("TAGGING OPENALEX WITH TOPICS")
-    print("loading openalex data")
+    logger.info("TAGGING OPENALEX WITH TOPICS")
+    logger.info("loading openalex data")
     openalex = get_openalex_entities()
     for level in range(1,len(taxonomy.columns)+1):
-        print("starting tagging for level {}".format(level))
+        logger.info("starting tagging for level {}".format(level))
         tax_at_level = taxonomy["Level_{}".format(level)]
         topics_per_doc = tag_docs_at_level(openalex, tax_at_level)
         if args.local:

--- a/dap_aria_mapping/pipeline/label_docs_with_taxonomy.py
+++ b/dap_aria_mapping/pipeline/label_docs_with_taxonomy.py
@@ -1,0 +1,103 @@
+from dap_aria_mapping.getters.taxonomies import get_cooccurrence_taxonomy, get_semantic_taxonomy
+from dap_aria_mapping.getters.openalex import get_openalex_entities
+from dap_aria_mapping.getters.patents import get_patent_entities
+from collections import defaultdict
+from dap_aria_mapping import BUCKET_NAME
+from nesta_ds_utils.loading_saving.S3 import upload_obj
+import pandas as pd
+import json
+import argparse
+
+def tag_docs_at_level(docs: dict, tax_at_level: pd.Series) -> dict:
+    """tag documents with topic labels based on entities present in document
+
+    Args:
+        docs (dict): dictionary where key: document id, value: list of entity information about each document
+        tax_at_level (pd.Series): taxonomy of entities, index: entity, value: topic of entity at a given level of the taxonomy
+
+    Returns:
+        dict: key: documentid, value: list of topics per document at given level of taxonomy 
+    """
+    topics_per_doc = defaultdict()
+    for docid, entity_list in docs.items():
+        doc_holder = []
+        for entity_info in entity_list:
+            try:
+                if entity_info["confidence"]>=80:
+                    topic = tax_at_level.loc[entity_info["entity"]]
+                    doc_holder.append(topic)
+            except KeyError:
+                continue
+        topics_per_doc[docid] = doc_holder
+    return topics_per_doc
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description="Test Mode", formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument(
+        "-t",
+        "--test_mode",
+        action="store_true",
+        help="run script in test mode on small sample",
+    )
+    parser.add_argument(
+        "-l",
+        "--local",
+        action="store_true",
+        help="option to output results locally",
+    )
+    parser.add_argument(
+        '--taxonomy',
+        required = True,
+        help='name of the taxonomy to use to label documents. Available optons are: cooccur, centroids, or imbalanced')
+    
+
+    args = parser.parse_args()
+    print("loading taxonomy")
+    if args.taxonomy == 'cooccur':
+        taxonomy = get_cooccurrence_taxonomy()
+    elif args.taxonomy == 'centroids':
+        taxonomy = get_semantic_taxonomy(cluster_object='centroids')
+    elif args.taxonomy == 'imbalanced':
+        taxonomy = get_semantic_taxonomy(cluster_object='imbalanced')
+    else:
+        print("INVALID TAXONOMY")
+    
+    print("TAGGING PATENTS WITH TOPICS")
+    print("loading patents data")
+    patents = get_patent_entities()
+    for level in range(1,len(taxonomy.columns)+1):
+        print("starting tagging for level {}".format(level))
+        tax_at_level = taxonomy["Level_{}".format(level)]
+        topics_per_doc = tag_docs_at_level(patents, tax_at_level)
+        if args.local:
+            with open('outputs/docs_with_topics/{}/patents/Level_{}.json'.format(args.taxonomy,level), 'w') as f:
+                json.dump(topics_per_doc,f)
+        else:
+            upload_obj(
+                topics_per_doc,
+                BUCKET_NAME,
+                'outputs/docs_with_topics/{}/patents/Level_{}.json'.format(args.taxonomy,level)
+            )
+        
+
+    print("TAGGING OPENALEX WITH TOPICS")
+    print("loading openalex data")
+    openalex = get_openalex_entities()
+    for level in range(1,len(taxonomy.columns)+1):
+        print("starting tagging for level {}".format(level))
+        tax_at_level = taxonomy["Level_{}".format(level)]
+        topics_per_doc = tag_docs_at_level(openalex, tax_at_level)
+        if args.local:
+            with open('outputs/docs_with_topics/{}/openalex/Level_{}.json'.format(args.taxonomy,level), 'w') as f:
+                json.dump(topics_per_doc,f)
+        else:
+            upload_obj(
+                topics_per_doc,
+                BUCKET_NAME,
+                'outputs/docs_with_topics/{}/openalex/Level_{}.json'.format(args.taxonomy,level)
+            )
+
+
+


### PR DESCRIPTION
---

# Description

Adds pipeline to tag documents with topics from a taxonomy

Fixes #55 

Modifies 3 scripts:
- getters/taxonomies: changes s3 file path for cooccurrence taxonomy
- getters/openalex: adds getter to fetch labeled openalex data
- getters/patents: adds getter to fetch labeled patents data

Adds 1 script:
- pipeline/label_docs_with_taxonomy.py: labels documents with taxonomy labels at all levels using a specified taxonomy and saves outputs either to s3 (default) or locally