### PR TITLE
[64] Pipeline script for topic-level novelty

### DIFF
--- a/dap_aria_mapping/getters/novelty.py
+++ b/dap_aria_mapping/getters/novelty.py
@@ -14,8 +14,8 @@ def get_openalex_novelty_scores(
     Downloads novelty scores for OpenAlex papers
 
     Args:
-        level (int): Taxonomy level that was used for novelty calculation
-        from_local (bool): Whether to load the data from local disk
+        level (int, optional): Taxonomy level that was used for novelty calculation. Defaults to 5.
+        from_local (bool, optional): Whether to load the data from local disk. Defaults to False.
 
     Returns:
         pd.DataFrame: Novelty scores for OpenAlex papers. Columns are:
@@ -45,8 +45,8 @@ def get_openalex_topic_pair_commonness(
     Downloads topic pair commonness scores for OpenAlex papers
 
     Args:
-        level (int): Taxonomy level that was used for commonness calculations
-        from_local (bool): Whether to load the data from local disk
+        level (int, optional): Taxonomy level that was used for commonness calculations. Defaults to 5.
+        from_local (bool, optional): Whether to load the data from local disk. Defaults to False.
 
     Returns:
         pd.DataFrame: Topic pair commonness scores for OpenAlex papers. Columns are:
@@ -82,8 +82,8 @@ def get_topic_novelty_openalex(
     levels of the taxonomy.
 
     Args:
-        level (int): Taxonomy level that was used for commonness calculations
-        from_local (bool): Whether to load the data from local disk
+        level (int, optional): Taxonomy level that was used for commonness calculations. Defaults to 5.
+        from_local (bool, optional): Whether to load the data from local disk. Defaults to False.
 
     Returns:
         pd.DataFrame: Table with topic-level novelty scores. Columns are:

--- a/dap_aria_mapping/getters/novelty.py
+++ b/dap_aria_mapping/getters/novelty.py
@@ -105,3 +105,62 @@ def get_topic_novelty_openalex(
             filepath,
             download_as="dataframe",
         )
+
+
+def get_patent_novelty_scores(level: int = 5, from_local: bool = False) -> pd.DataFrame:
+    """
+    Downloads novelty scores for patents
+
+    Args:
+        level (int): Taxonomy level that was used for novelty calculation
+        from_local (bool): Whether to load the data from local disk
+
+    Returns:
+        pd.DataFrame: Novelty scores for patents. Columns are:
+            - work_id: OpenAlex work id
+            - year: priority year
+            - commonness: commonness score for the patent
+            - novelty_score: novelty score for the patent
+            - n_topics: number of topics in the patent
+            - topics: list of topics in the patent
+
+    """
+    filepath = f"outputs/novelty/patent_novelty_{level}.parquet"
+    if from_local:
+        return pd.read_parquet(PROJECT_DIR / filepath)
+    else:
+        return download_obj(
+            BUCKET_NAME,
+            filepath,
+            download_as="dataframe",
+        )
+
+
+def get_patent_topic_pair_commonness(
+    level: int = 5, from_local: bool = False
+) -> pd.DataFrame:
+    """
+    Downloads topic pair commonness scores for patents
+
+    Args:
+        level (int): Taxonomy level that was used for commonness calculations
+        from_local (bool): Whether to load the data from local disk
+
+    Returns:
+        pd.DataFrame: Topic pair commonness scores for patents. Columns are:
+            - topic_1: first topic in the pair
+            - topic_2: second topic in the pair
+            - year: priority year
+            - N_ij_t: Number of co-occurrences of topic_1 and topic_2 in year t
+            - commonness: commonness score for the topic pair in year t
+
+    """
+    filepath = f"outputs/novelty/patent_topic_pair_commonness_{level}.parquet"
+    if from_local:
+        return pd.read_parquet(PROJECT_DIR / filepath)
+    else:
+        return download_obj(
+            BUCKET_NAME,
+            filepath,
+            download_as="dataframe",
+        )

--- a/dap_aria_mapping/getters/novelty.py
+++ b/dap_aria_mapping/getters/novelty.py
@@ -66,3 +66,42 @@ def get_openalex_topic_pair_commonness(
             filepath,
             download_as="dataframe",
         )
+
+
+def get_topic_novelty_openalex(
+    level: int = 5, from_local: bool = False
+) -> pd.DataFrame:
+    """
+    Downloads topic-level novelty score (based on OpenAlex papers).
+    There are two novelty scores: one based on aggregating document novelty scores,
+    and one based on aggregating topic pair novelty scores.
+
+    Note that for more granular levels, many of the topic pairs novelty scores
+    might be missing if they didn't meet the minimum number of pair count threshold.
+    To overcome this, one could use different pair count thresholds for different
+    levels of the taxonomy.
+
+    Args:
+        level (int): Taxonomy level that was used for commonness calculations
+        from_local (bool): Whether to load the data from local disk
+
+    Returns:
+        pd.DataFrame: Table with topic-level novelty scores. Columns are:
+            - topic: Topic identifier
+            - topic_name: Human-readable name of the topic
+            - year: Year to which the novelty score corresponds to
+            - topic_doc_novelty: Novelty measure based on aggregating document novelty scores
+            - doc_counts: Number of documents with the topic in the given year
+            - topic_pair_novelty: Alternative novelty measure based on aggregating topic pair novelty scores
+            - topic_pair_commonness: Aggregated topic commonness measure (ie, the inverse of topic pair novelty)
+            - pair_counts: Number of topic pairs with the topic in the given year
+    """
+    filepath = f"outputs/novelty/topic_novelty_openalex_{level}.parquet"
+    if from_local:
+        return pd.read_parquet(PROJECT_DIR / filepath)
+    else:
+        return download_obj(
+            BUCKET_NAME,
+            filepath,
+            download_as="dataframe",
+        )

--- a/dap_aria_mapping/getters/novelty.py
+++ b/dap_aria_mapping/getters/novelty.py
@@ -164,3 +164,42 @@ def get_patent_topic_pair_commonness(
             filepath,
             download_as="dataframe",
         )
+
+
+def get_topic_novelty_patents(
+    level: int = 5, from_local: bool = False
+) -> pd.DataFrame:
+    """
+    Downloads topic-level novelty score (based on patents).
+    There are two novelty scores: one based on aggregating document novelty scores,
+    and one based on aggregating topic pair novelty scores.
+
+    Note that for more granular levels, many of the topic pairs novelty scores
+    might be missing if they didn't meet the minimum number of pair count threshold.
+    To overcome this, one could use different pair count thresholds for different
+    levels of the taxonomy.
+
+    Args:
+        level (int): Taxonomy level that was used for commonness calculations
+        from_local (bool): Whether to load the data from local disk
+
+    Returns:
+        pd.DataFrame: Table with topic-level novelty scores. Columns are:
+            - topic: Topic identifier
+            - topic_name: Human-readable name of the topic
+            - year: Year to which the novelty score corresponds to
+            - topic_doc_novelty: Novelty measure based on aggregating document novelty scores
+            - doc_counts: Number of documents with the topic in the given year
+            - topic_pair_novelty: Alternative novelty measure based on aggregating topic pair novelty scores
+            - topic_pair_commonness: Aggregated topic commonness measure (ie, the inverse of topic pair novelty)
+            - pair_counts: Number of topic pairs with the topic in the given year
+    """
+    filepath = f"outputs/novelty/topic_novelty_patents_{level}.parquet"
+    if from_local:
+        return pd.read_parquet(PROJECT_DIR / filepath)
+    else:
+        return download_obj(
+            BUCKET_NAME,
+            filepath,
+            download_as="dataframe",
+        )

--- a/dap_aria_mapping/pipeline/novelty/calculate_openalex_novelty.py
+++ b/dap_aria_mapping/pipeline/novelty/calculate_openalex_novelty.py
@@ -5,10 +5,10 @@ Uses typer to create a command line interface
 Usage examples:
 
 All levels, full dataset:
-python dap_aria_mapping/notebooks/novelty/pipeline_openalex_novelty.py
+python dap_aria_mapping/pipeline/novelty/calculate_openalex_novelty.py
 
 One level, test dataset:
-python dap_aria_mapping/notebooks/novelty/pipeline_openalex_novelty.py --taxonomy-level 1 --test
+python dap_aria_mapping/pipeline/novelty/calculate_openalex_novelty.py --taxonomy-level 1 --test
 """
 from dap_aria_mapping import logging, PROJECT_DIR, BUCKET_NAME
 import dap_aria_mapping.getters.openalex as oa

--- a/dap_aria_mapping/pipeline/novelty/calculate_patent_novelty.py
+++ b/dap_aria_mapping/pipeline/novelty/calculate_patent_novelty.py
@@ -1,0 +1,102 @@
+""" 
+Script to calculate novelty scores for patents
+Uses typer to create a command line interface
+
+Usage examples:
+
+All levels, full dataset:
+python dap_aria_mapping/pipeline/novelty/calculate_patent_novelty.py
+
+One level, test dataset:
+python dap_aria_mapping/pipeline/novelty/calculate_patent_novelty.py --taxonomy-level 1 --test
+"""
+from dap_aria_mapping import logging, PROJECT_DIR, BUCKET_NAME
+from dap_aria_mapping.getters import patents
+import dap_aria_mapping.utils.novelty_utils as nu
+from nesta_ds_utils.loading_saving.S3 import upload_obj
+import typer
+
+OUTPUT_DIR = "outputs/novelty"
+
+
+def calculate_patent_novelty(
+    taxonomy_level: int = 0,
+    test: bool = False,
+    n_test_sample: int = 100,
+    save_to_local: bool = False,
+):
+    """
+    Calculates novelty scores for patents and uploads them on s3
+
+    Args:
+        taxonomy_level (int): Taxonomy level to use for novelty calculation. Must be between 1 and 5. If set to 0, uses all levels
+        test (bool): Whether to run in test mode (using a small sample of papers)
+        n_test_sample (int): Number of patents to use for testing
+        save_to_local (bool): Whether to also save the novelty scores to local disk
+
+    Returns:
+        None (saved novelty scores to file)
+    """
+    # Fetch patent metadata
+    patents_df = patents.get_patents()
+    logging.info(f"Downloaded {len(patents_df)} works")
+    # Decide on the taxonomy levels to use
+    if taxonomy_level == 0:
+        levels = list(range(1, 6))
+    else:
+        levels = [taxonomy_level]
+    # Loop over taxonomy levels
+    for level in levels:
+        logging.info(f"Processing taxonomy level {level}")
+        # Load topics for all papers
+        topics_dict = patents.get_patent_topics(level=level)
+        topics_df = nu.preprocess_topics_dict(
+            topics_dict,
+            patents_df.assign(priority_year=lambda df: df.priority_date.dt.year),
+            "publication_number",
+            "priority_year",
+        )
+        logging.info(
+            f"Using {len(topics_df)} patents with sufficient data for novelty calculation"
+        )
+        # Subsample for testing
+        test_suffix = ""
+        if test:
+            topics_df = topics_df.sample(n_test_sample)
+            test_suffix = f"_test_n{n_test_sample}"
+            logging.info(f"TEST MODE: Using {len(topics_df)} patents for testing")
+        # Calculate novelty scores
+        patent_novelty_df, topic_pair_commonness_df = nu.document_novelty(
+            topics_df, id_column="publication_number"
+        )
+        # Export novelty scores
+        filepath_document_novelty_scores = (
+            OUTPUT_DIR + f"/patent_novelty_{level}{test_suffix}.parquet"
+        )
+        filepath_topic_pair_commonness = (
+            OUTPUT_DIR + f"/patent_topic_pair_commonness_{level}{test_suffix}.parquet"
+        )
+        # Upload to s3
+        upload_obj(
+            patent_novelty_df,
+            BUCKET_NAME,
+            f"{filepath_document_novelty_scores}",
+        )
+        upload_obj(
+            topic_pair_commonness_df,
+            BUCKET_NAME,
+            f"{filepath_topic_pair_commonness}",
+        )
+        if save_to_local:
+            # Save to local disk
+            (PROJECT_DIR / OUTPUT_DIR).mkdir(parents=True, exist_ok=True)
+            export_path = PROJECT_DIR / filepath_document_novelty_scores
+            patent_novelty_df.to_parquet(export_path, index=False)
+            logging.info(f"Exported novelty scores to {export_path}")
+            export_path = PROJECT_DIR / filepath_topic_pair_commonness
+            topic_pair_commonness_df.to_parquet(export_path, index=False)
+            logging.info(f"Exported topic pair commonness to {export_path}")
+
+
+if __name__ == "__main__":
+    typer.run(calculate_patent_novelty)

--- a/dap_aria_mapping/pipeline/novelty/calculate_patent_novelty.py
+++ b/dap_aria_mapping/pipeline/novelty/calculate_patent_novelty.py
@@ -23,16 +23,19 @@ def calculate_patent_novelty(
     taxonomy_level: int = 0,
     test: bool = False,
     n_test_sample: int = 100,
+    upload_to_s3: bool = True,    
     save_to_local: bool = False,
 ):
     """
     Calculates novelty scores for patents and uploads them on s3
 
     Args:
-        taxonomy_level (int): Taxonomy level to use for novelty calculation. Must be between 1 and 5. If set to 0, uses all levels
-        test (bool): Whether to run in test mode (using a small sample of papers)
-        n_test_sample (int): Number of patents to use for testing
-        save_to_local (bool): Whether to also save the novelty scores to local disk
+        taxonomy_level (int, optional): Taxonomy level to use for novelty calculation. Must be between 1 and 5.
+            If set to 0, uses all levels. Defaults to 0.
+        test (bool, optional): Whether to run in test mode (using a small sample of papers). Defaults to False.
+        n_test_sample (int, optional): Number of patents to use for testing. Defaults to 100.
+        upload_to_s3 (bool, optional): Whether to upload the novelty scores to s3. Defaults to True.
+        save_to_local (bool, optional): Whether to also save the novelty scores to local disk. Defaults to False.
 
     Returns:
         None (saved novelty scores to file)
@@ -76,17 +79,18 @@ def calculate_patent_novelty(
         filepath_topic_pair_commonness = (
             OUTPUT_DIR + f"/patent_topic_pair_commonness_{level}{test_suffix}.parquet"
         )
-        # Upload to s3
-        upload_obj(
-            patent_novelty_df,
-            BUCKET_NAME,
-            f"{filepath_document_novelty_scores}",
-        )
-        upload_obj(
-            topic_pair_commonness_df,
-            BUCKET_NAME,
-            f"{filepath_topic_pair_commonness}",
-        )
+        if upload_to_s3:
+            # Upload to s3
+            upload_obj(
+                patent_novelty_df,
+                BUCKET_NAME,
+                f"{filepath_document_novelty_scores}",
+            )
+            upload_obj(
+                topic_pair_commonness_df,
+                BUCKET_NAME,
+                f"{filepath_topic_pair_commonness}",
+            )
         if save_to_local:
             # Save to local disk
             (PROJECT_DIR / OUTPUT_DIR).mkdir(parents=True, exist_ok=True)

--- a/dap_aria_mapping/pipeline/novelty/openalex_topic_novelty.py
+++ b/dap_aria_mapping/pipeline/novelty/openalex_topic_novelty.py
@@ -27,6 +27,7 @@ def calculate_topic_novelty(
     taxonomy_level: int = 0,
     from_local: bool = False,
     save_to_local: bool = False,
+    upload_to_s3: bool = True,
     min_pair_counts: int = 50,
     min_doc_counts: int = 50,
 ):
@@ -34,11 +35,14 @@ def calculate_topic_novelty(
     Calculate novelty scores for topics using OpenAlex data and uploads them on s3
 
     Args:
-        taxonomy_level (int, optional): Taxonomy level to use for novelty calculation. Must be between 1 and 5. If set to 0, uses all levels
+        taxonomy_level (int, optional): Taxonomy level to use for novelty calculation.
+            Must be between 1 and 5. If set to 0, uses all levels
         from_local (bool, optional): Whether to use data from local disk
         save_to_local (bool, optional): Whether to also save the novelty scores to local disk
-        min_pair_counts (int, optional): Minimum number of times a topic pair must appear in the corpus to be considered for novelty calculation (for the score based on topic pairs)
-        min_doc_counts (int, optional): Minimum number of times a topic must appear in the corpus to be considered for including into the analysis outputs
+        min_pair_counts (int, optional): Minimum number of times a topic pair must appear in the corpus
+            to be considered for novelty calculation (for the score based on topic pairs)
+        min_doc_counts (int, optional): Minimum number of times a topic must appear in the corpus
+            to be considered for including into the analysis outputs
     """
     if taxonomy_level == 0:
         levels = list(range(1, 6))
@@ -76,12 +80,13 @@ def calculate_topic_novelty(
         filepath_topic_novelty_scores = (
             OUTPUT_DIR + f"/topic_novelty_openalex_{level}.parquet"
         )
-        # Upload to s3
-        upload_obj(
-            topic_novelty_df,
-            BUCKET_NAME,
-            f"{filepath_topic_novelty_scores}",
-        )
+        if upload_to_s3:
+            # Upload to s3
+            upload_obj(
+                topic_novelty_df,
+                BUCKET_NAME,
+                f"{filepath_topic_novelty_scores}",
+            )
         if save_to_local:
             # Save to local disk
             (PROJECT_DIR / OUTPUT_DIR).mkdir(parents=True, exist_ok=True)

--- a/dap_aria_mapping/pipeline/novelty/openalex_topic_novelty.py
+++ b/dap_aria_mapping/pipeline/novelty/openalex_topic_novelty.py
@@ -1,0 +1,94 @@
+""" 
+Script to calculate novelty scores at topic level, using OpenAlex papers
+Uses typer to create a command line interface
+
+Usage examples:
+
+All levels, full dataset:
+python dap_aria_mapping/pipeline/novelty/openalex_topic_novelty.py
+
+One level, test dataset:
+python dap_aria_mapping/pipeline/novelty/openalex_topic_novelty.py --taxonomy-level 1
+"""
+from dap_aria_mapping import logging, PROJECT_DIR, BUCKET_NAME
+from dap_aria_mapping.getters.novelty import (
+    get_openalex_novelty_scores,
+    get_openalex_topic_pair_commonness,
+)
+import dap_aria_mapping.utils.novelty_utils as nu
+from dap_aria_mapping.getters.taxonomies import get_topic_names
+from nesta_ds_utils.loading_saving.S3 import upload_obj
+import typer
+
+OUTPUT_DIR = "outputs/novelty"
+
+
+def calculate_topic_novelty(
+    taxonomy_level: int = 0,
+    from_local: bool = False,
+    save_to_local: bool = False,
+    min_pair_counts: int = 50,
+    min_doc_counts: int = 50,
+):
+    """
+    Calculate novelty scores for topics using OpenAlex data and uploads them on s3
+
+    Args:
+        taxonomy_level (int, optional): Taxonomy level to use for novelty calculation. Must be between 1 and 5. If set to 0, uses all levels
+        from_local (bool, optional): Whether to use data from local disk
+        save_to_local (bool, optional): Whether to also save the novelty scores to local disk
+        min_pair_counts (int, optional): Minimum number of times a topic pair must appear in the corpus to be considered for novelty calculation (for the score based on topic pairs)
+        min_doc_counts (int, optional): Minimum number of times a topic must appear in the corpus to be considered for including into the analysis outputs
+    """
+    if taxonomy_level == 0:
+        levels = list(range(1, 6))
+    else:
+        levels = [taxonomy_level]
+    # Loop over taxonomy levels
+    for level in levels:
+        logging.info(f"Processing taxonomy level {level}")
+        # Fetch novelty scores for works
+        work_novelty_df = get_openalex_novelty_scores(
+            level=level, from_local=from_local
+        ).drop_duplicates("work_id")
+        # Fetch commonness values for topic pairs
+        topic_pairs_df = get_openalex_topic_pair_commonness(
+            level=level, from_local=from_local
+        )
+        # Fetch topic names
+        topic_names = get_topic_names(
+            taxonomy_class="cooccur", name_type="entity", level=level
+        )
+        # Calculate novelty scores for topics
+        topic_doc_novelty_df = nu.document_to_topic_novelty(work_novelty_df)
+        topic_pair_novelty_df = nu.pair_to_topic_novelty(
+            topic_pairs_df, min_counts=min_pair_counts
+        )
+        # Merge both topic-level novelty scores
+        topic_novelty_df = (
+            topic_doc_novelty_df.merge(
+                topic_pair_novelty_df, on=["topic", "year"], how="left"
+            )
+            .assign(topic_name=lambda x: x.topic.map(topic_names))
+            .query("doc_counts > @min_doc_counts")
+        )
+        # Export novelty scores
+        filepath_topic_novelty_scores = (
+            OUTPUT_DIR + f"/topic_novelty_openalex_{level}.parquet"
+        )
+        # Upload to s3
+        upload_obj(
+            topic_novelty_df,
+            BUCKET_NAME,
+            f"{filepath_topic_novelty_scores}",
+        )
+        if save_to_local:
+            # Save to local disk
+            (PROJECT_DIR / OUTPUT_DIR).mkdir(parents=True, exist_ok=True)
+            export_path = PROJECT_DIR / filepath_topic_novelty_scores
+            topic_novelty_df.to_parquet(export_path, index=False)
+            logging.info(f"Exported novelty scores to {export_path}")
+
+
+if __name__ == "__main__":
+    typer.run(calculate_topic_novelty)

--- a/dap_aria_mapping/pipeline/novelty/patent_topic_novelty.py
+++ b/dap_aria_mapping/pipeline/novelty/patent_topic_novelty.py
@@ -1,0 +1,94 @@
+""" 
+Script to calculate novelty scores at topic level, using patents
+Uses typer to create a command line interface
+
+Usage examples:
+
+All levels, full dataset:
+python dap_aria_mapping/pipeline/novelty/patent_topic_novelty.py
+
+One level, test dataset:
+python dap_aria_mapping/pipeline/novelty/patent_topic_novelty.py --taxonomy-level 1
+"""
+from dap_aria_mapping import logging, PROJECT_DIR, BUCKET_NAME
+from dap_aria_mapping.getters.novelty import (
+    get_patent_novelty_scores,
+    get_patent_topic_pair_commonness,
+)
+import dap_aria_mapping.utils.novelty_utils as nu
+from dap_aria_mapping.getters.taxonomies import get_topic_names
+from nesta_ds_utils.loading_saving.S3 import upload_obj
+import typer
+
+OUTPUT_DIR = "outputs/novelty"
+
+
+def calculate_topic_novelty(
+    taxonomy_level: int = 0,
+    from_local: bool = False,
+    save_to_local: bool = False,
+    min_pair_counts: int = 50,
+    min_doc_counts: int = 50,
+):
+    """
+    Calculate novelty scores for topics using patent data and uploads them on s3
+
+    Args:
+        taxonomy_level (int, optional): Taxonomy level to use for novelty calculation. Must be between 1 and 5. If set to 0, uses all levels
+        from_local (bool, optional): Whether to use data from local disk
+        save_to_local (bool, optional): Whether to also save the novelty scores to local disk
+        min_pair_counts (int, optional): Minimum number of times a topic pair must appear in the corpus to be considered for novelty calculation (for the score based on topic pairs)
+        min_doc_counts (int, optional): Minimum number of times a topic must appear in the corpus to be considered for including into the analysis outputs
+    """
+    if taxonomy_level == 0:
+        levels = list(range(1, 6))
+    else:
+        levels = [taxonomy_level]
+    # Loop over taxonomy levels
+    for level in levels:
+        logging.info(f"Processing taxonomy level {level}")
+        # Fetch novelty scores for patents
+        patent_novelty_df = get_patent_novelty_scores(
+            level=level, from_local=from_local
+        ).drop_duplicates("publication_number")
+        # Fetch commonness values for topic pairs
+        topic_pairs_df = get_patent_topic_pair_commonness(
+            level=level, from_local=from_local
+        )
+        # Fetch topic names
+        topic_names = get_topic_names(
+            taxonomy_class="cooccur", name_type="entity", level=level
+        )
+        # Calculate novelty scores for topics
+        topic_doc_novelty_df = nu.document_to_topic_novelty(patent_novelty_df, id_column="publication_number")
+        topic_pair_novelty_df = nu.pair_to_topic_novelty(
+            topic_pairs_df, min_counts=min_pair_counts
+        )
+        # Merge both topic-level novelty scores
+        topic_novelty_df = (
+            topic_doc_novelty_df.merge(
+                topic_pair_novelty_df, on=["topic", "year"], how="left"
+            )
+            .assign(topic_name=lambda x: x.topic.map(topic_names))
+            .query("doc_counts > @min_doc_counts")
+        )
+        # Export novelty scores
+        filepath_topic_novelty_scores = (
+            OUTPUT_DIR + f"/topic_novelty_patents_{level}.parquet"
+        )
+        # Upload to s3
+        upload_obj(
+            topic_novelty_df,
+            BUCKET_NAME,
+            f"{filepath_topic_novelty_scores}",
+        )
+        if save_to_local:
+            # Save to local disk
+            (PROJECT_DIR / OUTPUT_DIR).mkdir(parents=True, exist_ok=True)
+            export_path = PROJECT_DIR / filepath_topic_novelty_scores
+            topic_novelty_df.to_parquet(export_path, index=False)
+            logging.info(f"Exported novelty scores to {export_path}")
+
+
+if __name__ == "__main__":
+    typer.run(calculate_topic_novelty)

--- a/dap_aria_mapping/pipeline/novelty/patent_topic_novelty.py
+++ b/dap_aria_mapping/pipeline/novelty/patent_topic_novelty.py
@@ -27,6 +27,7 @@ def calculate_topic_novelty(
     taxonomy_level: int = 0,
     from_local: bool = False,
     save_to_local: bool = False,
+    upload_to_s3: bool = True,
     min_pair_counts: int = 50,
     min_doc_counts: int = 50,
 ):
@@ -76,12 +77,13 @@ def calculate_topic_novelty(
         filepath_topic_novelty_scores = (
             OUTPUT_DIR + f"/topic_novelty_patents_{level}.parquet"
         )
-        # Upload to s3
-        upload_obj(
-            topic_novelty_df,
-            BUCKET_NAME,
-            f"{filepath_topic_novelty_scores}",
-        )
+        if upload_to_s3:
+            # Upload to s3
+            upload_obj(
+                topic_novelty_df,
+                BUCKET_NAME,
+                f"{filepath_topic_novelty_scores}",
+            )
         if save_to_local:
             # Save to local disk
             (PROJECT_DIR / OUTPUT_DIR).mkdir(parents=True, exist_ok=True)

--- a/dap_aria_mapping/utils/novelty_utils.py
+++ b/dap_aria_mapping/utils/novelty_utils.py
@@ -42,8 +42,8 @@ def preprocess_topics_dict(
     Args:
         topics_dict (dict): A dictionary with document IDs as keys and a list of topics as values
         metadata_df (pd.DataFrame): Metadata dataframe with columns id_column and publication_year
-        id_column (str): Name of the column in metadata_df that contains the document IDs
-        year_column (str): Name of the column in metadata_df that contains the publication year
+        id_column (str, optional): Name of the column in metadata_df that contains the document IDs. Defaults to "work_id".
+        year_column (str, optional): Name of the column in metadata_df that contains the publication year. Defaults to "publication_year".
 
     Returns:
         pd.DataFrame: A dataframe with columns "work_id", "year" and "topics"
@@ -79,7 +79,7 @@ def document_novelty(
 
     Args:
         topics_df (pd.DataFrame): A dataframe with columns for document id, "year" and "topics"
-        id_column (str, optional): Name of the column that contains document ids. Defaults to 'work_id'.
+        id_column (str, optional): Name of the column that contains document ids. Defaults to "work_id".
 
     Returns:
         pd.DataFrame: A dataframe with document novelty, with columns "work_id", "year", "novelty", "n_topics" and "topics"
@@ -148,7 +148,7 @@ def get_document_topic_pairs(
 
     Args:
         document_table (pd.DataFrame): Dataframe with columns id_column, "years" and "topics"
-        id_column (str, optional): Name of the column that contains document ids. Defaults to 'document_id'.
+        id_column (str, optional): Name of the column that contains document ids. Defaults to "document_id".
 
     Returns:
         pd.DataFrame: A dataframe with columns "work_id", "topic_1", "topic_2", "year"
@@ -201,6 +201,7 @@ def get_counts_of_pairs_with_topic(
 
     Args:
         document_topic_pairs (dict): Dataframe with columns for "work_id", "topic_1", "topic_2", "counts"
+        id_column (str, optional): Name of the column that contains document ids. Defaults to "work_id".
 
     Returns:
         Dict[str, int]: Dictionary with topic as key and pair counts as value
@@ -293,6 +294,7 @@ def document_to_topic_novelty(
 
     Args:
         document_novelty (pd.DataFrame): A dataframe with novelty scores and list of topics for each document
+        id_column (str, optional): The column name for the document id. Defaults to "work_id". Defaults to "work_id".
         aggregation (str, optional): The aggregation to use. Defaults to "median".
 
     Returns:
@@ -310,7 +312,7 @@ def document_to_topic_novelty(
 
 def pair_to_topic_novelty(
     topic_pair_commonness: pd.DataFrame,
-    aggregation: str = lambda x: aggregate_document_commonness(x),
+    aggregation: str = "10th_percentile",
     min_counts: int = 0,
 ) -> pd.DataFrame:
     """
@@ -318,7 +320,8 @@ def pair_to_topic_novelty(
 
     Args:
         topic_pair_commonness (pd.DataFrame): Dataframe with columns "topic_1", "topic_2", "year", "commonness", "N_ij_t"
-        aggregation (_type_, optional): Aggregation method. Defaults to taking the 10th percentile of commoness scores
+        aggregation (str, optional): Method that will be used by the pd.DataFrame.groupby().agg() to aggregate commonness scores.
+            Defaults to '10th percentile'.
         min_counts (int, optional): Minimum number of times a topic pair must appear to be included in the calculation. Defaults to 0.
 
     Returns:
@@ -338,6 +341,10 @@ def pair_to_topic_novelty(
         ignore_index=True,
     )
     # Aggregate the commonness scores across topics, and convert to a novelty score
+    if aggregation == "10th_percentile":
+        aggregation = lambda x: aggregate_document_commonness(x, percentile=10)
+    else:
+        aggregation = aggregation
     return (
         df.groupby(["topic", "year"], as_index=False)
         .agg(


### PR DESCRIPTION
Closes #64 

The main addition is the pipeline for calculating a topic-level novelty score, characterising the "uncommonness" of the research related to a given topic (in a given year).

The usage is as follows:

```
python dap_aria_mapping/pipeline/novelty/openalex_topic_novelty.py
```

This will output five tables (on per each taxonomy level), with two alternative novelty scores per topic, per year.

At the moment, this is based only on the OpenAlex data.

In a forthcoming issue/PR, I will apply the same analysis on patent data, to generate novelty scores using patents as well.

# Checklist:

- [x] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [x] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [x] I have documented the code
  - [x] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [x] I have explained this PR above
- [x] I have requested a code review
