### PR TITLE
83 disruption chart

### DIFF
--- a/dap_aria_mapping/analysis/app/pages/2_Change_Makers.py
+++ b/dap_aria_mapping/analysis/app/pages/2_Change_Makers.py
@@ -2,7 +2,7 @@ import streamlit as st
 from PIL import Image
 from nesta_ds_utils.viz.altair import formatting
 from dap_aria_mapping import PROJECT_DIR, IMAGE_DIR
-from dap_aria_mapping.getters.app_tables.change_makers import get_collaboration_network, get_quad_chart_data
+from dap_aria_mapping.getters.app_tables.change_makers import get_collaboration_network, get_quad_chart_data, get_topic_domain_area_lookup
 from streamlit_agraph import agraph, Node, Edge, Config
 import networkx as nx
 from typing import Tuple, List
@@ -14,17 +14,51 @@ formatting.setup_theme()
 
 PAGE_TITLE = "Change Makers"
 
-#icon to be used as the favicon on the browser tab
+# icon to be used as the favicon on the browser tab
 icon = Image.open(f"{IMAGE_DIR}/cm_icon.ico")
 
 # sets page configuration with favicon and title
 st.set_page_config(
-    page_title=PAGE_TITLE, 
-    layout="wide", 
+    page_title=PAGE_TITLE,
+    layout="wide",
     page_icon=icon
 )
 
-@st.cache_data(show_spinner = "Loading Data")
+
+@st.cache_data(show_spinner="Loading data for filter")
+def load_filter_data() -> pl.DataFrame:
+    """load a lookup table of area, domain, topic names to populate filter
+
+    Returns:
+        pl.DataFrame: lookup table for filters
+    """
+    filter_data = get_topic_domain_area_lookup(doc_type="both")
+    return filter_data, filter_data.get_column("domain_name").unique().to_list()
+
+
+@st.cache_data(show_spinner="Filtering")
+def filter_filter_options(
+        filter_field: str,
+        filter_val: str,
+        _filter_data: pl.DataFrame,
+        return_field: str) -> Tuple[pl.DataFrame, List[str]]:
+    """filters the data used to populate the filters based on the selection
+
+    Args:
+        filter_field (str): field to filter based on level selected
+        filter_val (str): value to filter 
+        filter_data (pl.DataFrame): data used to populate filter
+        return_field (str): field to return to populate next level of filter
+
+    Returns:
+        pl.DataFrame: filtered filter data
+        List[str]: list of unique values for filter
+    """
+    filtered_data = _filter_data.filter(pl.col(filter_field) == filter_val)
+    return filtered_data, filtered_data.get_column(return_field).unique().to_list()
+
+
+@st.cache_resource(show_spinner="Loading Data")
 def load_networks(dataset: str) -> nx.Graph:
     """get the collaboration network for either patents or publications
 
@@ -36,7 +70,8 @@ def load_networks(dataset: str) -> nx.Graph:
     """
     return get_collaboration_network(dataset)
 
-@st.cache_data(show_spinner = "Filtering Data to Domain")
+
+@st.cache_data(show_spinner="Filtering Data to Domain")
 def filter_network_by_domain(domain: str, dataset: str) -> Tuple[nx.Graph, List[str]]:
     """generates options for the topic filter, and filters the network to only contain nodes of a given domain
 
@@ -47,13 +82,15 @@ def filter_network_by_domain(domain: str, dataset: str) -> Tuple[nx.Graph, List[
     Returns:
         Tuple[nx.Graph, List[str]]: subgraph only containing nodes within the domain, and unique areas to populate filter
     """
-    #must load the network in the function, otherwise won't be able to go back to another domain
+    # must load the network in the function, otherwise won't be able to go back to another domain
     network = load_networks(dataset)
     node_domains = nx.get_node_attributes(network, "domains")
-    nodes = [node for node in network.nodes() if domain in node_domains[node]["domain_name"]]
-    return network.subgraph(nodes) 
+    nodes = [node for node in network.nodes(
+    ) if domain in node_domains[node]["domain_name"]]
+    return network.subgraph(nodes)
 
-@st.cache_data(show_spinner = "Filtering Data to Area")
+
+@st.cache_data(show_spinner="Filtering Data to Area")
 def filter_network_by_area(area: str, _network: nx.Graph) -> Tuple[nx.Graph, List[str]]:
     """generates options for the topic filter, and filters the network to only contain nodes of a given domain
 
@@ -65,9 +102,11 @@ def filter_network_by_area(area: str, _network: nx.Graph) -> Tuple[nx.Graph, Lis
     Returns:
         Tuple[nx.Graph, List[str]]: subgraph only containing nodes within the area, and unique topics to populate filter
     """
-    node_areas= nx.get_node_attributes(_network, "areas")
-    nodes = [node for node in network.nodes() if area in node_areas[node]["area_name"]]
+    node_areas = nx.get_node_attributes(_network, "areas")
+    nodes = [node for node in network.nodes(
+    ) if area in node_areas[node]["area_name"]]
     return network.subgraph(nodes)
+
 
 @st.cache_data
 def filter_network_by_topic(topic: str, _network: nx.Graph) -> nx.Graph:
@@ -80,11 +119,13 @@ def filter_network_by_topic(topic: str, _network: nx.Graph) -> nx.Graph:
     Returns:
        nx.Graph : subgraph only containing nodes within the topic
     """
-    node_topics= nx.get_node_attributes(_network, "topics")
-    nodes = [node for node in network.nodes() if topic in node_topics[node]["topic_name"]]
+    node_topics = nx.get_node_attributes(_network, "topics")
+    nodes = [node for node in network.nodes(
+    ) if topic in node_topics[node]["topic_name"]]
     return network.subgraph(nodes)
 
-@st.cache_data
+
+@st.cache_resource
 def nx_to_agraph(_network: nx.Graph, filter_val: str, filter_field: str, id_col: str) -> Tuple[List[Node], List[Edge]]:
     """convert networkx graph to lists of streamlit-agraph nodes and edges.
 
@@ -103,35 +144,38 @@ def nx_to_agraph(_network: nx.Graph, filter_val: str, filter_field: str, id_col:
     nodes = [
         Node(
             id=node,
-            label = node,
-            size = math.log(node_size[node][id_col]),
-            shape = "dot",
-            color = "#0f294a")
-            for node in _network.nodes()]
+            label=node,
+            size=math.log(node_size[node][id_col]),
+            shape="dot",
+            color="#0f294a")
+        for node in _network.nodes()]
     edges = [
         Edge(
             source=edge[0],
             weight=edge_weight[edge][filter_val],
             target=edge[1],
-            color = "EB003B"
-            ) for edge in _network.edges()]
-            
+            color="EB003B"
+        ) for edge in _network.edges()]
+
     return nodes, edges
 
-@st.cache_data(show_spinner = "Loading quad chart")
-def load_quad_data():
+
+@st.cache_data(show_spinner="Loading quad chart")
+def load_quad_data(year: int):
     """gets the disruption and volume by institution to populate the quad chart
+
+    Args:
+        year (int): year for which data to load - specified by filter
 
     Returns:
         pl.DataFrame: polars dataframe with columns 
-        ["domain_name", "area_name", "topic_name", "affiliation_string", "volume", "average_cd_score", "average_novelty_score"]
+        ["domain_name", "area_name", "topic_name", "affiliation_string", "volume", "average_cd_score", "average_novelty_score", "year"]
     """
-    quad_data = get_quad_chart_data()
-    domain_filter_options = quad_data["domain_name"].unique().to_list()
-    return quad_data, domain_filter_options
+    return get_quad_chart_data(year)
 
-@st.cache_data(show_spinner = "Filtering by domain")
-def filter_quad_by_domain(_quad_data: pl.DataFrame, domain: str) -> Tuple[pl.DataFrame, List[str]]:
+
+@st.cache_data(show_spinner="Filtering by domain")
+def filter_quad_by_domain(_quad_data: pl.DataFrame, domain: str) -> pl.DataFrame:
     """filters the quad chart data by a domain
 
     Args:
@@ -139,17 +183,17 @@ def filter_quad_by_domain(_quad_data: pl.DataFrame, domain: str) -> Tuple[pl.Dat
         domain (str): domain selected by filter
 
     Returns:
-        Tuple[pl.DataFrame, List[str]]: filtered quad chart data, list of unique areas to populate filter
+        pl.DataFrame: filtered quad chart data
     """
     quad_data = _quad_data.filter(
-        pl.col("domain_name")==domain
-        )
+        pl.col("domain_name") == domain
+    )
 
-    unique_areas = quad_data["area_name"].unique().to_list()
-    return quad_data, unique_areas
+    return quad_data
 
-@st.cache_data(show_spinner = "Filtering by area")
-def filter_quad_by_area(_quad_data: pl.DataFrame, area: str) -> Tuple[pl.DataFrame, List[str]]:
+
+@st.cache_data(show_spinner="Filtering by area")
+def filter_quad_by_area(_quad_data: pl.DataFrame, area: str) -> pl.DataFrame:
     """filters the quad chart data by a topic
 
     Args:
@@ -157,16 +201,16 @@ def filter_quad_by_area(_quad_data: pl.DataFrame, area: str) -> Tuple[pl.DataFra
         area (str): area selected by filter
 
     Returns:
-        Tuple[pl.DataFrame, List[str]]: filtered quad chart data, list of unique topics to populate filter
+        pl.DataFrame: filtered quad chart data
     """
     quad_data = _quad_data.filter(
-        pl.col("area_name")==area
-        )
-    unique_topics = quad_data["topic_name"].unique().to_list()
+        pl.col("area_name") == area
+    )
 
-    return quad_data, unique_topics
+    return quad_data
 
-@st.cache_data(show_spinner = "Filtering by topic")
+
+@st.cache_data(show_spinner="Filtering by topic")
 def filter_quad_by_topic(_quad_data: pl.DataFrame, topic: str) -> pl.DataFrame:
     """filters the quad data by an area
 
@@ -177,7 +221,7 @@ def filter_quad_by_topic(_quad_data: pl.DataFrame, topic: str) -> pl.DataFrame:
     Returns:
         pl.DataFrame: filtered quad chart data
     """
-    return _quad_data.filter(pl.col("topic_name")==topic)
+    return _quad_data.filter(pl.col("topic_name") == topic)
 
 
 def group_quad_data(_quad_data: pl.DataFrame, select_field: str) -> pl.DataFrame:
@@ -192,41 +236,48 @@ def group_quad_data(_quad_data: pl.DataFrame, select_field: str) -> pl.DataFrame
         pl.DataFrame: grouped quad chart data
     """
     q = (
-    _quad_data.lazy()
-    .select(
+        _quad_data.lazy()
+        .select(
             [pl.col("affiliation_string"),
-            pl.col("volume"),
-            pl.col(select_field)
-            ]
+             pl.col("volume"),
+             pl.col(select_field)
+             ]
         )
-    .drop_nulls()
-    .groupby(["affiliation_string"])
-    .agg([
-        pl.sum("volume").alias("volume"),
-        pl.mean(select_field).alias(select_field)
+        .drop_nulls()
+        .groupby(["affiliation_string"])
+        .agg([
+            pl.sum("volume").alias("volume"),
+            pl.mean(select_field).alias(select_field)
         ])
     )
     return q.collect()
-    
-header1, header2 = st.columns([1,10])
+
+
+header1, header2 = st.columns([1, 10])
 with header1:
     st.image(icon)
-with header2:       
-    st.markdown(f'<h1 style="color:#EB003B;font-size:72px;">{"Change Makers"}</h1>', unsafe_allow_html=True)
+with header2:
+    st.markdown(
+        f'<h1 style="color:#EB003B;font-size:72px;">{"Change Makers"}</h1>', unsafe_allow_html=True)
 
-st.markdown(f'<h1 style="color:#EB003B;font-size:16px;">{"<em>Find the people and institutions with the ability to make waves within research areas<em>"}</h1>', unsafe_allow_html=True)
+st.markdown(
+    f'<h1 style="color:#EB003B;font-size:16px;">{"<em>Find the people and institutions with the ability to make waves within research areas<em>"}</h1>', unsafe_allow_html=True)
 
 overview_tab, collaboration_tab = st.tabs(["Overview", "Collaboration"])
 
 with overview_tab:
     dropdown1, dropdown2, dropdown3 = st.columns(3)
     with dropdown1:
-        #In theory this would say "Individuals", "Institutions", or "Research Groups"
-        group = st.selectbox(label = "Show me the:" , options = ["Institutions"])
+        # In theory this would say "Individuals", "Institutions", or "Research Groups"
+        group = st.selectbox(label="Show me the:", options=["Institutions"])
     with dropdown2:
-        #Currently only showing disruptive
-        indicator = st.selectbox(label = "Who are producing research that is:", options = ["Disruptive", "Novel"])
-    
+        # Currently only showing disruptive
+        indicator = st.selectbox(label="Who are producing research that is:", options=[
+                                 "Disruptive", "Novel"])
+    with dropdown3:
+        year = st.selectbox(label="During the year:", options=[
+                            2016, 2017, 2018, 2019, 2020])
+
     if indicator == "Disruptive":
         select_field = "average_cd_score"
         axis_title = "Average C-D Score"
@@ -235,96 +286,111 @@ with overview_tab:
         select_field = "average_novelty_score"
         axis_title = "Average Novelty Score"
 
-    
-    quad_data, domain_filter_options = load_quad_data()
+    quad_data = load_quad_data(year)
+    filter_data, domain_filter_options = load_filter_data()
 
     with st.sidebar:
-        domain = st.selectbox(label = "Select a Domain", options = domain_filter_options)
+        domain = st.selectbox(label="Select a Domain",
+                              options=domain_filter_options)
         area = "All"
         topic = "All"
-        quad_data, area_filter_options = filter_quad_by_domain(quad_data, domain)
+        filtered_data, area_filter_options = filter_filter_options(
+            "domain_name", domain, filter_data, "area_name")
+        quad_data = filter_quad_by_domain(
+            quad_data, domain)
         area_filter_options.insert(0, "All")
-        area = st.selectbox(label = "Select a Area", options = area_filter_options)
+        area = st.selectbox(label="Select an Area", options=area_filter_options)
 
         if area != "All":
-            quad_data, topic_filter_options = filter_quad_by_area(quad_data, area)
-            topic_filter_options.insert(0, "All")
-            topic = st.selectbox(label = "Select a Topic", options = topic_filter_options)
-            
+            quad_data = filter_quad_by_area(
+                quad_data, area)
+            filtered_data, topic_filter_options = filter_filter_options(
+                "area_name", area, filtered_data, "topic_name")
+            topic = st.selectbox(label="Select a Topic",
+                                 options=topic_filter_options)
+
             if topic != "All":
 
                 quad_data = filter_quad_by_topic(quad_data, topic)
-    
-    quad_data_to_plot = group_quad_data(quad_data, select_field).to_pandas()
-    quad_chart = alt.Chart(quad_data_to_plot).mark_circle().encode(
-        x = alt.X("volume:Q", axis = alt.Axis(tickCount = 2, title = "Total Publications"), scale = alt.Scale(domain = [0, quad_data_to_plot["volume"].max()])),
-        y = alt.Y("{}:Q".format(select_field), axis = alt.Axis(tickCount = 2, title = axis_title)),
-        tooltip = [
-            alt.Tooltip(field = "affiliation_string", title = "Organisation"),
-            alt.Tooltip(field = "volume", title = "Total Publications"),
-            alt.Tooltip(field = select_field, title = axis_title)]
-    ).properties(width = 1200, height = 500).configure_mark(color = "#0000FF").interactive()
 
-    st.altair_chart(quad_chart)
+    if quad_data.is_empty():
+        st.markdown(
+            "Sorry, no {} data in this area, domain, and/or topic for {}".format(indicator, year))
+    else:
+        quad_data_to_plot = group_quad_data(quad_data, select_field).to_pandas()
+        quad_chart = alt.Chart(quad_data_to_plot).mark_circle().encode(
+            x=alt.X("volume:Q", axis=alt.Axis(tickCount=2, title="Total Publications"),
+                    scale=alt.Scale(domain=[0, quad_data_to_plot["volume"].max()])),
+            y=alt.Y("{}:Q".format(select_field), axis=alt.Axis(
+                tickCount=2, title=axis_title)),
+            tooltip=[
+                alt.Tooltip(field="affiliation_string", title="Organisation"),
+                alt.Tooltip(field="volume", title="Total Publications"),
+                alt.Tooltip(field=select_field, title=axis_title)]
+        ).properties(width=1200, height=500).configure_mark(color="#0000FF").interactive()
+
+        st.altair_chart(quad_chart)
 
 
 with collaboration_tab:
     network_dropdown1, network_dropdown2 = st.columns(2)
     with network_dropdown1:
-        dataset = st.selectbox(label = "Show me relationships in", options = ["Industry", "Academia"])
+        dataset = st.selectbox(label="Show me relationships in", options=[
+                               "Industry", "Academia"])
         if dataset == "Academia":
             id_col = "id"
             org_name_col = "affiliation_string"
         else:
             id_col = "publication_number"
             org_name_col = "assignee_harmonized_names"
-    
-    level = "domain"
-    #NOTE: YOU MUST SELECT A DOMAIN
 
-    #allow user to filter by area, but also allow "all"
+    level = "domain"
     no_network = False
     network = filter_network_by_domain(domain, dataset)
-    nodes, edges = nx_to_agraph(network, domain, filter_field = "domains", id_col = id_col)
+    nodes, edges = nx_to_agraph(
+        network, domain, filter_field="domains", id_col=id_col)
     if area != "All":
         level = "area"
-        #if an area is selected, filter data to the area and allow user to filter by topic or select "all"
         network = filter_network_by_area(area, network)
         try:
-            nodes, edges = nx_to_agraph(network, area, filter_field = "areas", id_col= id_col)
+            nodes, edges = nx_to_agraph(
+                network, area, filter_field="areas", id_col=id_col)
         except KeyError:
             no_network = True
-            st.markdown("No groups in the top 500 institutions in {} produced research in {}".format(dataset, area))
+            st.markdown("No groups in the top 500 institutions in {} produced research in {}".format(
+                dataset, area))
 
         if topic != "All":
             level = "topic"
             network = filter_network_by_topic(topic, network)
             try:
-                nodes, edges = nx_to_agraph(network, topic, filter_field = "topics", id_col=id_col)
+                nodes, edges = nx_to_agraph(
+                    network, topic, filter_field="topic_name", id_col=id_col)
             except KeyError:
                 no_network = True
-                st.markdown("No groups in the top 500 institutions in {} produced research in {}".format(dataset, area))
+                st.markdown("No groups in the top 500 institutions in {} produced research in {}".format(
+                    dataset, area))
 
     st.subheader("Collaboration Network")
     st.markdown("🚨 This view is currently **experimental** and only shows relationships in the most productive 500 institutions in patents and publications")
-    
+
     config = Config(width=1100,
-                height=950,
-                directed=False, 
-                physics=True, 
-                hierarchical=False,
-                # **kwargs
-                )
+                    height=950,
+                    directed=False,
+                    physics=True,
+                    hierarchical=False,
+                    # **kwargs
+                    )
 
     if not no_network:
         agraph(nodes, edges, config)
 
 
-#adds the nesta x aria logo at the bottom of each tab, 3 lines below the contents
+# adds the nesta x aria logo at the bottom of each tab, 3 lines below the contents
 st.markdown("")
 st.markdown("")
 st.markdown("")
 
-white_space, logo, white_space = st.columns([1.5,1,1.5])
+white_space, logo, white_space = st.columns([1.5, 1, 1.5])
 with logo:
     st.image(Image.open(f"{IMAGE_DIR}/igl_nesta_aria_logo.png"))

--- a/dap_aria_mapping/getters/app_tables/change_makers.py
+++ b/dap_aria_mapping/getters/app_tables/change_makers.py
@@ -40,3 +40,17 @@ def get_topic_domain_area_lookup(doc_type: str) -> pl.DataFrame:
         ]).unique(subset = "topic")
     else:
         print("Invalid doctype option")
+
+def get_quad_chart_data() -> pl.DataFrame:
+    """gets the disruption and volume by institution to populate the quad chart
+
+    Returns:
+        pl.DataFrame: polars dataframe with columns ["domain_name", "area_name", "topic_name", "affiliation_string", "volume", "average_cd_score"]
+    """
+    return pl.DataFrame(
+        download_obj(
+            BUCKET_NAME, 
+            "outputs/app_data/change_makers/disruption_by_institution.parquet",
+            download_as = "dataframe"
+            )
+        )

--- a/dap_aria_mapping/getters/app_tables/change_makers.py
+++ b/dap_aria_mapping/getters/app_tables/change_makers.py
@@ -3,6 +3,7 @@ from dap_aria_mapping import BUCKET_NAME
 import networkx as nx
 import polars as pl
 
+
 def get_collaboration_network(dataset: str) -> nx.Graph:
     """get the collaboration network for either patents or publications
 
@@ -19,6 +20,7 @@ def get_collaboration_network(dataset: str) -> nx.Graph:
     else:
         return "Not implemented"
 
+
 def get_topic_domain_area_lookup(doc_type: str) -> pl.DataFrame:
     """get a table of all topic (level 3), area (level 2), and domain (level 1) names (via chatgpt) to use to populate filters.
         Uses either topics present in patents, publications, or both
@@ -30,27 +32,33 @@ def get_topic_domain_area_lookup(doc_type: str) -> pl.DataFrame:
         pl.DataFrame: all unique topics and their corresponding area and domain names
     """
     if doc_type == "patents":
-        return pl.DataFrame(download_obj(BUCKET_NAME, "outputs/app_data/patent_topic_filter_lookup.parquet", download_as = "dataframe"))
+        return pl.DataFrame(download_obj(BUCKET_NAME, "outputs/app_data/patent_topic_filter_lookup.parquet", download_as="dataframe"))
     elif doc_type == "publications":
-        return pl.DataFrame(download_obj(BUCKET_NAME, "outputs/app_data/publication_topic_filter_lookup.parquet", download_as = "dataframe"))
+        return pl.DataFrame(download_obj(BUCKET_NAME, "outputs/app_data/publication_topic_filter_lookup.parquet", download_as="dataframe"))
     elif doc_type == "both":
         return pl.concat([
-            pl.DataFrame(download_obj(BUCKET_NAME, "outputs/app_data/patent_topic_filter_lookup.parquet", download_as = "dataframe")),
-            pl.DataFrame(download_obj(BUCKET_NAME, "outputs/app_data/publication_topic_filter_lookup.parquet", download_as = "dataframe"))
-        ]).unique(subset = "topic")
+            pl.DataFrame(download_obj(
+                BUCKET_NAME, "outputs/app_data/patent_topic_filter_lookup.parquet", download_as="dataframe")),
+            pl.DataFrame(download_obj(
+                BUCKET_NAME, "outputs/app_data/publication_topic_filter_lookup.parquet", download_as="dataframe"))
+        ]).unique(subset=["domain_name", "area_name", "topic_name"])
     else:
         print("Invalid doctype option")
 
-def get_quad_chart_data() -> pl.DataFrame:
+
+def get_quad_chart_data(year: int) -> pl.DataFrame:
     """gets the disruption and volume by institution to populate the quad chart
 
+    Args:
+        year (int): year of data to load
     Returns:
         pl.DataFrame: polars dataframe with columns ["domain_name", "area_name", "topic_name", "affiliation_string", "volume", "average_cd_score"]
     """
     return pl.DataFrame(
         download_obj(
-            BUCKET_NAME, 
-            "outputs/app_data/change_makers/disruption_by_institution.parquet",
-            download_as = "dataframe"
-            )
+            BUCKET_NAME,
+            "outputs/app_data/change_makers/disruption/disruption_by_institution_{}.parquet".format(
+                year),
+            download_as="dataframe"
         )
+    )

--- a/dap_aria_mapping/getters/openalex.py
+++ b/dap_aria_mapping/getters/openalex.py
@@ -97,9 +97,19 @@ def get_openalex_topics(tax: str = "cooccur", level: int = 1) -> Dict[str, List[
 
     return download_obj(
         BUCKET_NAME,
-        "outputs/docs_with_topics/{}/openalex/Level_{}.json".format(tax, str(level)),
+        "outputs/docs_with_topics/{}/openalex/Level_{}.json".format(
+            tax, str(level)),
         download_as="dict",
     )
+
+
+def get_openalex_institutes():
+    return download_obj(
+        AI_GENOMICS_BUCKET_NAME,
+        "inputs/openalex/institutions.json",
+        download_as="dict",
+    )
+
 
 def get_openalex_cd_scores(year: int) -> Dict[str, int]:
     """From S3 loads openalex CD scores for a given year..
@@ -125,7 +135,7 @@ def get_openalex_institutes():
     )
 
 
-#########TEMPORARY AI GENOMICS GETTERS##########################
+######### TEMPORARY AI GENOMICS GETTERS##########################
 
 
 def get_openalex_ai_genomics_works() -> pd.DataFrame:
@@ -256,7 +266,6 @@ def get_openalex_forward_citations(
         f"{directory}{fname}",
         download_as="dict",
     )
-
 
 
 # We didn't use this table - it looks like it would need cleaning up if you were keen

--- a/dap_aria_mapping/getters/openalex.py
+++ b/dap_aria_mapping/getters/openalex.py
@@ -258,6 +258,22 @@ def get_openalex_forward_citations(
     )
 
 
+def get_openalex_cd_scores(year: int) -> Dict:
+    """From S3 loads openalex CD scores for a given year..
+
+    Args:
+        year (int): The year for which to fetch CD scores.
+
+    Returns:
+        Dict: Dictionary mapping work IDs to CD scores.
+    """
+    return download_obj(
+        BUCKET_NAME,
+        f"outputs/openalex_cd_scores_{year}.json",
+        download_as="dict",
+    )
+
+
 # We didn't use this table - it looks like it would need cleaning up if you were keen
 # to use meSH information
 def get_openalex_mesh() -> pd.DataFrame:

--- a/dap_aria_mapping/getters/openalex.py
+++ b/dap_aria_mapping/getters/openalex.py
@@ -268,6 +268,22 @@ def get_openalex_forward_citations(
     )
 
 
+def get_openalex_cd_scores(year: int) -> Dict:
+    """From S3 loads openalex CD scores for a given year..
+
+    Args:
+        year (int): The year for which to fetch CD scores.
+
+    Returns:
+        Dict: Dictionary mapping work IDs to CD scores.
+    """
+    return download_obj(
+        BUCKET_NAME,
+        f"outputs/openalex_cd_scores_{year}.json",
+        download_as="dict",
+    )
+
+
 # We didn't use this table - it looks like it would need cleaning up if you were keen
 # to use meSH information
 def get_openalex_mesh() -> pd.DataFrame:

--- a/dap_aria_mapping/getters/openalex.py
+++ b/dap_aria_mapping/getters/openalex.py
@@ -113,7 +113,7 @@ def get_openalex_cd_scores(year: int) -> Dict[str, int]:
     """
     return download_obj(
         BUCKET_NAME,
-        f"outputs/cd_index/openalex_cd_scores_{year}.json",
+        "outputs/cd_index/openalex_cd_scores_{}.json".format(year),
         download_as="dict",
     )
 
@@ -257,21 +257,6 @@ def get_openalex_forward_citations(
         download_as="dict",
     )
 
-
-def get_openalex_cd_scores(year: int) -> Dict:
-    """From S3 loads openalex CD scores for a given year..
-
-    Args:
-        year (int): The year for which to fetch CD scores.
-
-    Returns:
-        Dict: Dictionary mapping work IDs to CD scores.
-    """
-    return download_obj(
-        BUCKET_NAME,
-        f"outputs/openalex_cd_scores_{year}.json",
-        download_as="dict",
-    )
 
 
 # We didn't use this table - it looks like it would need cleaning up if you were keen

--- a/dap_aria_mapping/getters/taxonomies.py
+++ b/dap_aria_mapping/getters/taxonomies.py
@@ -152,7 +152,6 @@ def get_topic_names(
     postproc: bool = True,
 ) -> Dict[str, str]:
     """Downloads topic names from S3 and returns them as a dictionary.
-
     Args:
         taxonomy_class (str): The type of taxonomy to download.
         name_type (str): The type of name to download.
@@ -161,6 +160,7 @@ def get_topic_names(
             chatgpt name_type uses 35 entities per topic to hit the API endpoint.
         postproc (bool, optional): Whether to download the postprocessed topic names. Defaults to False.
 
+        postproc (bool, optional): Whether to download the postprocessed topic names. Defaults to True.
     Returns:
         pd.DataFrame: A dictionary containing the topic names.
     """

--- a/dap_aria_mapping/getters/taxonomies.py
+++ b/dap_aria_mapping/getters/taxonomies.py
@@ -1,7 +1,9 @@
 from dap_aria_mapping import BUCKET_NAME, PROJECT_DIR
 from typing import Dict
 from nesta_ds_utils.loading_saving.S3 import download_obj
-import boto3, yaml, pickle
+import boto3
+import yaml
+import pickle
 import pandas as pd
 from toolz import pipe
 
@@ -79,7 +81,8 @@ def get_cooccurrence_taxonomy(
     if sample:
         return download_obj(
             BUCKET_NAME,
-            "outputs/community_detection_taxonomy/{}.parquet".format(str(sample)),
+            "outputs/community_detection_taxonomy/{}.parquet".format(
+                str(sample)),
             download_as="dataframe",
         )
     

--- a/dap_aria_mapping/getters/taxonomies.py
+++ b/dap_aria_mapping/getters/taxonomies.py
@@ -181,7 +181,7 @@ def get_topic_names(
                 download_as="dict",
             )
     else:
-        if name_type!="chatgpt":
+        if name_type != "chatgpt":
             return download_obj(
                 BUCKET_NAME,
                 f"outputs/topic_names/class_{taxonomy_class}_nametype_{name_type}_top_{str(n_top)}_level_{str(level)}.json",

--- a/dap_aria_mapping/pipeline/app_tables/collaboration_network.py
+++ b/dap_aria_mapping/pipeline/app_tables/collaboration_network.py
@@ -12,11 +12,12 @@ from itertools import combinations, chain
 from collections import Counter, defaultdict
 from nesta_ds_utils.loading_saving.S3 import upload_obj
 
+
 def docs_per_org(
-    orgs_df: pl.DataFrame, 
-    id_col: str = "publication_number", 
-    org_name_col: str = "assignee_harmonized_names",
-    top_n: Union[int, bool] = False) -> Union[Dict[str, int], Tuple[Dict[str,int], List[str]]]:
+        orgs_df: pl.DataFrame,
+        id_col: str = "publication_number",
+        org_name_col: str = "assignee_harmonized_names",
+        top_n: Union[int, bool] = False) -> Union[Dict[str, int], Tuple[Dict[str, int], List[str]]]:
     """Creates a dataframe with the total number of documents generated per institution/organisation. 
         Used to generate node weights.
 
@@ -31,23 +32,23 @@ def docs_per_org(
     """
     q = (
         orgs_df.lazy()
-        .unique(subset = [id_col,org_name_col])
+        .unique(subset=[id_col, org_name_col])
         .groupby(org_name_col)
         .agg([pl.count(id_col)])
-        .sort(id_col, descending = True, nulls_last = True)
-        )
+        .sort(id_col, descending=True, nulls_last=True)
+    )
     if top_n:
         df = q.collect().limit(top_n).to_pandas()
         top_orgs = df[org_name_col].to_list()
-        return (df.set_index(org_name_col).to_dict(orient = "index"), top_orgs)
+        return (df.set_index(org_name_col).to_dict(orient="index"), top_orgs)
     else:
-        return q.collect().to_pandas().set_index(org_name_col).to_dict(orient = "index")
+        return q.collect().to_pandas().set_index(org_name_col).to_dict(orient="index")
 
 
 def node_data(
-    orgs_df_with_topics: pl.DataFrame, 
-    by: str = "topic", 
-    org_name_col: str = "assignee_harmonized_names") -> Dict[str, List[str]]:
+        orgs_df_with_topics: pl.DataFrame,
+        by: str = "topic",
+        org_name_col: str = "assignee_harmonized_names") -> Dict[str, List[str]]:
     """generates a dictionary of domains, areas, or topics (specified with by) that an organisation/institution has
     produced at least one document in. Used to populate node attributes.
 
@@ -62,17 +63,18 @@ def node_data(
             value: list of either domains, areas, or topics associated with the org/institution
     """
     q = (
-    orgs_df_with_topics.lazy()
-    .groupby(org_name_col)
-    .agg([pl.col(by)])
+        orgs_df_with_topics.lazy()
+        .groupby(org_name_col)
+        .agg([pl.col(by)])
     )
     df = q.collect()
-    return df.to_pandas().set_index(org_name_col).to_dict(orient = "index")
+    return df.to_pandas().set_index(org_name_col).to_dict(orient="index")
+
 
 def get_edges(
-    orgs_df: pl.DataFrame,
-    id_col: str = "publication_number", 
-    org_name_col: str = "assignee_harmonized_names") -> Dict[Tuple[str,str], int]:
+        orgs_df: pl.DataFrame,
+        id_col: str = "publication_number",
+        org_name_col: str = "assignee_harmonized_names") -> Dict[Tuple[str, str], int]:
     """gets all pairs of orgs/institutions that have collaborated at least once on a document.
         Used to created edges.
 
@@ -86,20 +88,22 @@ def get_edges(
     """
     q = (
         orgs_df.lazy()
-        .unique(subset = [id_col, org_name_col])
+        .unique(subset=[id_col, org_name_col])
         .groupby(id_col)
         .agg([pl.col(org_name_col)])
-        )
+    )
     df = q.collect()
     sequences = df[org_name_col].to_list()
-    combos = list(combinations(sorted(set(sequence)), 2) for sequence in sequences)
+    combos = list(combinations(sorted(set(sequence)), 2)
+                  for sequence in sequences)
     return Counter(chain(*combos))
 
+
 def edge_data(
-    orgs_df_with_topics: pl.DataFrame,
-    by: str = "topic",
-    id_col: str = "publication_number", 
-    org_name_col: str = "assignee_harmonized_names") -> Dict[str, Dict[str, int]]:
+        orgs_df_with_topics: pl.DataFrame,
+        by: str = "topic",
+        id_col: str = "publication_number",
+        org_name_col: str = "assignee_harmonized_names") -> Dict[str, Dict[str, int]]:
     """calculates the total number of documents within a domain, area, topic that a pair of institutions/orgs have collaborated on
         Used to add metadata to the edges for filtering.
 
@@ -121,19 +125,20 @@ def edge_data(
         .groupby([by, id_col])
         .agg([
             pl.col(org_name_col)
-            ])
-        )
+        ])
+    )
     df = q.collect()
     unique_topics = df[by].unique().to_list()
     edge_data = defaultdict(lambda: defaultdict(int))
     for topic in unique_topics:
         topic_data = df.filter(pl.col(by) == topic)
         sequences = topic_data[org_name_col].to_list()
-        combos = list(combinations(sorted(set(sequence)), 2) for sequence in sequences)
+        combos = list(combinations(sorted(set(sequence)), 2)
+                      for sequence in sequences)
         topic_combos = Counter(chain(*combos))
-        
+
         for combo in topic_combos:
-            edge_data[combo][topic] +=1
+            edge_data[combo][topic] += 1
     return edge_data
 
 
@@ -151,15 +156,15 @@ if __name__ == "__main__":
 
     parser.add_argument(
         "--level",
-        default = "institutions",
+        default="institutions",
         type=str,
-        help = "options: institutions or individuals"
+        help="options: institutions or individuals"
     )
 
     parser.add_argument(
         "--top_n",
-        default= False,
-        type = int,
+        default=False,
+        type=int,
         required=False
     )
 
@@ -169,7 +174,7 @@ if __name__ == "__main__":
         logger.info("Loading openalex institutes data")
         authorships = pl.DataFrame(
             get_openalex_authorships()).select([pl.col("id"), pl.col("affiliation_string")]
-        )
+                                               )
         id_col = "id"
         org_name_col = "affiliation_string"
 
@@ -177,13 +182,13 @@ if __name__ == "__main__":
         pubs_with_topics_df = pl.DataFrame(
             pd.DataFrame.from_dict(
                 get_openalex_topics(tax="cooccur", level=3), orient='index')
-                .T
-                .unstack()
-                .dropna()
-                .reset_index(drop=True, level=1)
-                .to_frame()
-                .reset_index()
-                )
+            .T
+            .unstack()
+            .dropna()
+            .reset_index(drop=True, level=1)
+            .to_frame()
+            .reset_index()
+        )
         pubs_with_topics_df.columns = [id_col, "topic"]
 
         # add institutions affiliated with authors to publications tagged with topics
@@ -194,7 +199,7 @@ if __name__ == "__main__":
         ).filter(
             ~pl.all(pl.col(org_name_col).is_null())
         )
-    
+
     elif args.doc_type == "patents" and args.level == "institutions":
         id_col = "publication_number"
         org_name_col = "assignee_harmonized_names"
@@ -216,22 +221,24 @@ if __name__ == "__main__":
         )
 
         patents_with_topics_df.columns = [id_col, "topic"]
-        
+
         logger.info("Formatting patents data")
-        #add assignees and the assignee types to patents tagged with topics
+        # add assignees and the assignee types to patents tagged with topics
         df = patents_with_topics_df.join(docs, how="left", on=id_col)
 
-        #explode assignee name and type columns so each row contains a single assignee and the associated type vs a list
-        #NOTE: I DONT THINK THIS WORKS PROPERLY AS THE LISTS OF NAME TYPES SEEM TO BE OUT OF ORDER OF THE NAMES (see patent WO-2012141480-A2)
+        # explode assignee name and type columns so each row contains a single assignee and the associated type vs a list
+        # NOTE: I DONT THINK THIS WORKS PROPERLY AS THE LISTS OF NAME TYPES SEEM TO BE OUT OF ORDER OF THE NAMES (see patent WO-2012141480-A2)
         df = df.filter(
-            pl.col(org_name_col).arr.lengths() == pl.col("assignee_harmonized_names_types").arr.lengths()
+            pl.col(org_name_col).arr.lengths() == pl.col(
+                "assignee_harmonized_names_types").arr.lengths()
         ).explode(
             [org_name_col, "assignee_harmonized_names_types"]
         )
-        #only consider organisations (not individuals)
-        orgs_df = df.filter(pl.col("assignee_harmonized_names_types") == "ORGANISATION")
+        # only consider organisations (not individuals)
+        orgs_df = df.filter(
+            pl.col("assignee_harmonized_names_types") == "ORGANISATION")
 
-    #add area and domain col
+    # add area and domain col
     orgs_df_with_topics = add_area_domain_chatgpt_names(
         expand_topic_col(orgs_df).unique(subset=[id_col, "topic", org_name_col])
     )
@@ -239,32 +246,39 @@ if __name__ == "__main__":
     logger.info("GENERATING NETWORK")
     network = nx.Graph()
 
-    logger.info("Adding nodes with the following attributes: topics, areas, domains")
+    logger.info(
+        "Adding nodes with the following attributes: topics, areas, domains")
     if args.top_n:
         print("Only including top {} orgs".format(args.top_n))
-        node_metadata, nodes =  docs_per_org(orgs_df, id_col, org_name_col, top_n=args.top_n)
+        node_metadata, nodes = docs_per_org(
+            orgs_df, id_col, org_name_col, top_n=args.top_n)
         orgs_df = orgs_df.filter(pl.col(org_name_col).is_in(nodes))
-        orgs_df_with_topics = orgs_df_with_topics.filter(pl.col(org_name_col).is_in(nodes))
+        orgs_df_with_topics = orgs_df_with_topics.filter(
+            pl.col(org_name_col).is_in(nodes))
         network.add_nodes_from(nodes)
     else:
         node_metadata = docs_per_org(orgs_df, id_col, org_name_col)
         network.add_nodes_from(set(orgs_df[org_name_col]))
 
-    nx.set_node_attributes(network,node_metadata, "overall_doc_count")
-    nx.set_node_attributes(network, node_data(orgs_df_with_topics, "topic_name", org_name_col), "topics")
-    nx.set_node_attributes(network, node_data(orgs_df_with_topics, "area_name", org_name_col), "areas")
-    nx.set_node_attributes(network, node_data(orgs_df_with_topics, "domain_name", org_name_col), "domains")
+    nx.set_node_attributes(network, node_metadata, "overall_doc_count")
+    nx.set_node_attributes(network, node_data(
+        orgs_df_with_topics, "topic_name", org_name_col), "topics")
+    nx.set_node_attributes(network, node_data(
+        orgs_df_with_topics, "area_name", org_name_col), "areas")
+    nx.set_node_attributes(network, node_data(
+        orgs_df_with_topics, "domain_name", org_name_col), "domains")
 
     logger.info("Adding edges")
     edges = get_edges(orgs_df, id_col, org_name_col)
     network.add_edges_from(list(edges.keys()))
     nx.set_edge_attributes(network, edges, "overall_doc_count")
-    nx.set_edge_attributes(network, edge_data(orgs_df_with_topics, by="topic_name", id_col= id_col, org_name_col = org_name_col), "topics")
-    nx.set_edge_attributes(network, edge_data(orgs_df_with_topics, by="area_name", id_col= id_col, org_name_col= org_name_col), "areas")
-    nx.set_edge_attributes(network, edge_data(orgs_df_with_topics, by="domain_name", id_col= id_col, org_name_col= org_name_col), "domains")
+    nx.set_edge_attributes(network, edge_data(
+        orgs_df_with_topics, by="topic_name", id_col=id_col, org_name_col=org_name_col), "topics")
+    nx.set_edge_attributes(network, edge_data(
+        orgs_df_with_topics, by="area_name", id_col=id_col, org_name_col=org_name_col), "areas")
+    nx.set_edge_attributes(network, edge_data(
+        orgs_df_with_topics, by="domain_name", id_col=id_col, org_name_col=org_name_col), "domains")
 
     print("Saving network")
-    upload_obj(network, BUCKET_NAME, "outputs/app_data/change_makers/networks/{}_{}.pkl".format(args.doc_type, args.level))
-
-
-
+    upload_obj(network, BUCKET_NAME,
+               "outputs/app_data/change_makers/networks/{}_{}.pkl".format(args.doc_type, args.level))

--- a/dap_aria_mapping/pipeline/app_tables/collaboration_network.py
+++ b/dap_aria_mapping/pipeline/app_tables/collaboration_network.py
@@ -159,7 +159,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--top_n",
         default= False,
-        type = Union[bool,int],
+        type = int,
         required=False
     )
 

--- a/dap_aria_mapping/pipeline/app_tables/quad_chart.py
+++ b/dap_aria_mapping/pipeline/app_tables/quad_chart.py
@@ -4,6 +4,7 @@ NOTE: CURRENTLY ONLY INCLUDES PATENTS PUBLISHED IN 2017
 
 from dap_aria_mapping.getters.openalex import get_openalex_topics, get_openalex_cd_scores, get_openalex_authorships
 from dap_aria_mapping.utils.app_data_utils import expand_topic_col, add_area_domain_chatgpt_names
+from dap_aria_mapping.getters.novelty import get_openalex_novelty_scores
 import polars as pl
 import pandas as pd
 from dap_aria_mapping import logger, BUCKET_NAME
@@ -12,21 +13,27 @@ import boto3
 
 if __name__ == "__main__":
 
-    logger.info("Loading publication cd scores")
-    #NOTE: CURRENTLY ONLY USING 2017 DATA - ONCE PIPELINE IS RUN ON ALL YEARS THIS WILL NEED TO AGGREGATE ALL AVAILABLE YEARS
-    cd_scores = pl.DataFrame(
-            pd.DataFrame.from_dict(
-                get_openalex_cd_scores(year=2017), orient='index')
-                .T
-                .unstack()
-                .dropna()
-                .reset_index(drop=True, level=1)
-                .to_frame()
-                .reset_index()
-                )
+    logger.info("Loading and aggregating publication cd scores")
+    years = [2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017]
+    cd_scores = pl.DataFrame(data = None)
+    for year in years:
+        df = pl.DataFrame(
+                    pd.DataFrame.from_dict(
+                        get_openalex_cd_scores(year), orient='index')
+                        .T
+                        .unstack()
+                        .dropna()
+                        .reset_index(drop=True, level=1)
+                        .to_frame()
+                        .reset_index()
+                        )
+        cd_scores = pl.concat([cd_scores, df])
     cd_scores.columns = ["id", "cd_score"]
 
-    #cd_ids = cd_scores["id"].to_list()
+    logger.info("Loading publication novelty scores")
+
+
+    logger.info("Have c-d scores for {} publications".format(len(cd_scores)))
 
     logger.info("Loading publication authorship info and filtering to only include docs with cd scores")
     authorships = pl.DataFrame(get_openalex_authorships()

--- a/dap_aria_mapping/pipeline/app_tables/quad_chart.py
+++ b/dap_aria_mapping/pipeline/app_tables/quad_chart.py
@@ -1,5 +1,4 @@
-"""generates backend of quad chart for change makers tab with disruption indicator
-NOTE: CURRENTLY ONLY INCLUDES PATENTS PUBLISHED IN 2017
+"""generates backend of quad chart for change makers tab with disruption and novelty indicators
 """
 
 from dap_aria_mapping.getters.openalex import get_openalex_topics, get_openalex_cd_scores, get_openalex_authorships
@@ -15,40 +14,39 @@ if __name__ == "__main__":
 
     logger.info("Loading and aggregating publication cd scores")
     years = [2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017]
-    cd_scores = pl.DataFrame(data = None)
+    cd_scores = pl.DataFrame(data=None)
     for year in years:
         df = pl.DataFrame(
             pd.DataFrame.from_dict(
-                get_openalex_cd_scores(year), orient='index'
-            )
+                get_openalex_cd_scores(year), orient='index')
             .T
             .unstack()
             .dropna()
             .reset_index(drop=True, level=1)
             .to_frame()
             .reset_index()
-        )
+        ).with_columns(pl.lit(year).alias("year"))
         cd_scores = pl.concat([cd_scores, df])
-    cd_scores.columns = ["id", "cd_score"]
-
-    logger.info("Loading publication novelty scores")
-
+    cd_scores.columns = ["id", "cd_score", "year"]
     logger.info("Have c-d scores for {} publications".format(len(cd_scores)))
 
-    logger.info("Loading publication authorship info and filtering to only include docs with cd scores")
-    authorships = pl.DataFrame(
-        get_openalex_authorships()
-    ).select(
-        [pl.col("id"), pl.col("affiliation_string")]
-    ).filter(
-        pl.col("id").is_in(cd_scores["id"])
-    )
+    logger.info("Loading publication novelty scores")
+    novelty_scores = pl.DataFrame(get_openalex_novelty_scores(level=3)).select(pl.col(
+        "work_id"), pl.col("novelty"), pl.col("year")).rename({"work_id": "id"})
+    logger.info("Have novelty scores for {} publications".format(
+        len(novelty_scores)))
 
-    logger.info("Loading publications with topics and filtering to only include docs with cd scores")
+    scores_df = cd_scores.join(novelty_scores, on="id", how="outer")
+
+    logger.info("Loading publication authorship info")
+    authorships = pl.DataFrame(get_openalex_authorships()
+                               ).select([pl.col("id"), pl.col("affiliation_string")]
+                                        )
+
+    logger.info("Loading publications with topics")
     pubs_with_topics_df = pl.DataFrame(
         pd.DataFrame.from_dict(
-            get_openalex_topics(tax = "cooccur", level = 3), orient='index'
-        )
+            get_openalex_topics(tax="cooccur", level=3), orient='index')
         .T
         .unstack()
         .dropna()
@@ -59,36 +57,39 @@ if __name__ == "__main__":
 
     pubs_with_topics_df.columns = ["id", "topic"]
 
-    pubs_with_topics_df = pubs_with_topics_df.filter(pl.col("id").is_in(cd_scores["id"]))
-
-    logger.info("Calculating volume and average cd score per organisation per topic")
+    logger.info("Calculating volume, average cd score per organisation per topic, and average novelty score per organisation per topic")
 
     orgs_df_with_topics_and_scores = pubs_with_topics_df.join(
-        authorships, on = "id", how = "left"
+        authorships, on="id", how="left"
     ).filter(
         ~pl.all(pl.col('affiliation_string').is_null())
     ).join(
-        cd_scores, on = "id", how = "left"
+        scores_df, on="id", how="left"
     )
-
     q = (
         orgs_df_with_topics_and_scores.lazy()
-        .groupby(["affiliation_string", "topic"])
+        .groupby(["affiliation_string", "topic", "year"])
         .agg([
             pl.count("id").alias("volume"),
-            pl.mean("cd_score").alias("average_cd_score")
-            ])
-        )
+            pl.mean("cd_score").alias("average_cd_score"),
+            pl.mean("novelty").alias("average_novelty_score")
+        ])
+    )
 
     aggregated_data = q.collect()
 
     logger.info("Adding topic names")
 
-    aggregated_data_with_names = add_area_domain_chatgpt_names(expand_topic_col(aggregated_data))
-    
-    logger.info("Uploading file to S3")
-    buffer = io.BytesIO()
-    aggregated_data_with_names.write_parquet(buffer)
-    buffer.seek(0)
-    s3 = boto3.client("s3")
-    s3.upload_fileobj(buffer, BUCKET_NAME, "outputs/app_data/change_makers/disruption_by_institution.parquet")
+    aggregated_data_with_names = add_area_domain_chatgpt_names(
+        expand_topic_col(aggregated_data))
+
+    logger.info("Uploading yearly files to S3")
+    years = aggregated_data_with_names[["year"]].unique()
+    for year in years:
+        yearly_data = aggregated_data_with_names.filter(pl.col("year") == year)
+        buffer = io.BytesIO()
+        yearly_data.write_parquet(buffer)
+        buffer.seek(0)
+        s3 = boto3.client("s3")
+        s3.upload_fileobj(buffer, BUCKET_NAME,
+                          "outputs/app_data/change_makers/disruption/disruption_by_institution_{}.parquet".format(year))

--- a/dap_aria_mapping/pipeline/app_tables/quad_chart.py
+++ b/dap_aria_mapping/pipeline/app_tables/quad_chart.py
@@ -1,0 +1,81 @@
+"""generates backend of quad chart for change makers tab with disruption indicator
+NOTE: CURRENTLY ONLY INCLUDES PATENTS PUBLISHED IN 2017
+"""
+
+from dap_aria_mapping.getters.openalex import get_openalex_topics, get_openalex_cd_scores, get_openalex_authorships
+from dap_aria_mapping.utils.app_data_utils import expand_topic_col, add_area_domain_chatgpt_names
+import polars as pl
+import pandas as pd
+from dap_aria_mapping import logger, BUCKET_NAME
+import io
+import boto3
+
+if __name__ == "__main__":
+
+    logger.info("Loading publication cd scores")
+    #NOTE: CURRENTLY ONLY USING 2017 DATA - ONCE PIPELINE IS RUN ON ALL YEARS THIS WILL NEED TO AGGREGATE ALL AVAILABLE YEARS
+    cd_scores = pl.DataFrame(
+            pd.DataFrame.from_dict(
+                get_openalex_cd_scores(year=2017), orient='index')
+                .T
+                .unstack()
+                .dropna()
+                .reset_index(drop=True, level=1)
+                .to_frame()
+                .reset_index()
+                )
+    cd_scores.columns = ["id", "cd_score"]
+
+    #cd_ids = cd_scores["id"].to_list()
+
+    logger.info("Loading publication authorship info and filtering to only include docs with cd scores")
+    authorships = pl.DataFrame(get_openalex_authorships()
+        ).select([pl.col("id"), pl.col("affiliation_string")]
+        ).filter(pl.col("id").is_in(cd_scores["id"]))
+
+    logger.info("Loading publications with topics and filtering to only include docs with cd scores")
+    pubs_with_topics_df = pl.DataFrame(
+        pd.DataFrame.from_dict(
+            get_openalex_topics(tax = "cooccur", level = 3), orient='index')
+            .T
+            .unstack()
+            .dropna()
+            .reset_index(drop=True, level=1)
+            .to_frame()
+            .reset_index()
+            )
+
+    pubs_with_topics_df.columns = ["id", "topic"]
+
+    pubs_with_topics_df = pubs_with_topics_df.filter(pl.col("id").is_in(cd_scores["id"]))
+
+    logger.info("Calculating volume and average cd score per organisation per topic")
+
+    orgs_df_with_topics_and_scores = pubs_with_topics_df.join(
+            authorships, on = "id", how = "left"
+            ).filter(
+                ~pl.all(pl.col('affiliation_string').is_null())
+                ).join(
+                    cd_scores, on = "id", how = "left"
+                )
+    q = (
+        orgs_df_with_topics_and_scores.lazy()
+        .groupby(["affiliation_string", "topic"])
+        .agg([
+            pl.count("id").alias("volume"),
+            pl.mean("cd_score").alias("average_cd_score")
+            ])
+        )
+
+    aggregated_data = q.collect()
+
+    logger.info("Adding topic names")
+
+    aggregated_data_with_names =  add_area_domain_chatgpt_names(expand_topic_col(aggregated_data))
+    
+    logger.info("Uploading file to S3")
+    buffer = io.BytesIO()
+    aggregated_data_with_names.write_parquet(buffer)
+    buffer.seek(0)
+    s3 = boto3.client("s3")
+    s3.upload_fileobj(buffer, BUCKET_NAME, "outputs/app_data/change_makers/disruption_by_institution.parquet")

--- a/dap_aria_mapping/pipeline/app_tables/topic_name_lookup.py
+++ b/dap_aria_mapping/pipeline/app_tables/topic_name_lookup.py
@@ -32,11 +32,11 @@ if __name__ == "__main__":
 
     unique_pub_topics = pubs_with_topics_df.unique(subset="topic")
     pub_topics_with_names = add_area_domain_chatgpt_names(
-        expand_topic_col(unique_pub_topics))
+        expand_topic_col(unique_pub_topics)).select((pl.col("domain_name"), pl.col("area_name"), pl.col("topic_name")))
 
     unique_patent_topics = patents_with_topics_df.unique(subset="topic")
     patent_topics_with_names = add_area_domain_chatgpt_names(
-        expand_topic_col(unique_patent_topics))
+        expand_topic_col(unique_patent_topics)).select((pl.col("domain_name"), pl.col("area_name"), pl.col("topic_name")))
 
     logger.info("Saving publication lookup table to s3")
     buffer = io.BytesIO()

--- a/dap_aria_mapping/pipeline/app_tables/topic_name_lookup.py
+++ b/dap_aria_mapping/pipeline/app_tables/topic_name_lookup.py
@@ -53,13 +53,3 @@ if __name__ == "__main__":
     s3 = boto3.client("s3")
     s3.upload_fileobj(buffer, BUCKET_NAME,
                       "outputs/app_data/patent_topic_filter_lookup.parquet")
-
-    logger.info("Saving combined lookup table to S3")
-    combined_filter = pl.concat(
-        [pub_topics_with_names, patent_topics_with_names]).unique()
-    buffer = io.BytesIO()
-    combined_filter.write_parquet(buffer)
-    buffer.seek(0)
-    s3 = boto3.client("s3")
-    s3.upload_fileobj(buffer, BUCKET_NAME,
-                      "outputs/app_data/combined_topic_filter_lookup.parquet")

--- a/dap_aria_mapping/pipeline/app_tables/topic_name_lookup.py
+++ b/dap_aria_mapping/pipeline/app_tables/topic_name_lookup.py
@@ -14,39 +14,52 @@ import boto3
 
 if __name__ == "__main__":
     logger.info("Loading patent data")
-    patents_with_topics = get_patent_topics(tax = "cooccur", level = 3)
+    patents_with_topics = get_patent_topics(tax="cooccur", level=3)
     patents_with_topics_df = pl.DataFrame(
         pd.DataFrame.from_dict(patents_with_topics, orient='index'
-        ).T.unstack().dropna().reset_index(drop=True, level=1).to_frame().reset_index())
+                               ).T.unstack().dropna().reset_index(drop=True, level=1).to_frame().reset_index())
 
     patents_with_topics_df.columns = ["publication_number", "topic"]
 
     logger.info("Loading publication data")
-    pubs_with_topics = get_openalex_topics(tax = "cooccur", level = 3)
+    pubs_with_topics = get_openalex_topics(tax="cooccur", level=3)
     pubs_with_topics_df = pl.DataFrame(
         pd.DataFrame.from_dict(pubs_with_topics, orient='index'
-        ).T.unstack().dropna().reset_index(drop=True, level=1).to_frame().reset_index())
+                               ).T.unstack().dropna().reset_index(drop=True, level=1).to_frame().reset_index())
     pubs_with_topics_df.columns = ["publication_number", "topic"]
-    
+
     logger.info("Creating lookup tables")
 
-    unique_pub_topics = pubs_with_topics_df.unique(subset = "topic")
-    pub_topics_with_names = add_area_domain_chatgpt_names(expand_topic_col(unique_pub_topics))
+    unique_pub_topics = pubs_with_topics_df.unique(subset="topic")
+    pub_topics_with_names = add_area_domain_chatgpt_names(
+        expand_topic_col(unique_pub_topics))
 
-    unique_patent_topics = patents_with_topics_df.unique(subset = "topic")
-    patent_topics_with_names = add_area_domain_chatgpt_names(expand_topic_col(unique_patent_topics))
-    
-    logger.info("Saving lookup table to s3")
+    unique_patent_topics = patents_with_topics_df.unique(subset="topic")
+    patent_topics_with_names = add_area_domain_chatgpt_names(
+        expand_topic_col(unique_patent_topics))
+
+    logger.info("Saving publication lookup table to s3")
     buffer = io.BytesIO()
     pub_topics_with_names.write_parquet(buffer)
     buffer.seek(0)
     s3 = boto3.client("s3")
-    s3.upload_fileobj(buffer, BUCKET_NAME, "outputs/app_data/publication_topic_filter_lookup.parquet")
+    s3.upload_fileobj(buffer, BUCKET_NAME,
+                      "outputs/app_data/publication_topic_filter_lookup.parquet")
 
-    logger.info("Saving lookup table to s3")
+    logger.info("Saving patent lookup table to s3")
     buffer = io.BytesIO()
     patent_topics_with_names.write_parquet(buffer)
     buffer.seek(0)
     s3 = boto3.client("s3")
-    s3.upload_fileobj(buffer, BUCKET_NAME, "outputs/app_data/patent_topic_filter_lookup.parquet")
+    s3.upload_fileobj(buffer, BUCKET_NAME,
+                      "outputs/app_data/patent_topic_filter_lookup.parquet")
 
+    logger.info("Saving combined lookup table to S3")
+    combined_filter = pl.concat(
+        [pub_topics_with_names, patent_topics_with_names]).unique()
+    buffer = io.BytesIO()
+    combined_filter.write_parquet(buffer)
+    buffer.seek(0)
+    s3 = boto3.client("s3")
+    s3.upload_fileobj(buffer, BUCKET_NAME,
+                      "outputs/app_data/combined_topic_filter_lookup.parquet")

--- a/dap_aria_mapping/pipeline/novelty/openalex_topic_novelty.py
+++ b/dap_aria_mapping/pipeline/novelty/openalex_topic_novelty.py
@@ -45,7 +45,7 @@ def calculate_topic_novelty(
             to be considered for including into the analysis outputs
     """
     if taxonomy_level == 0:
-        levels = list(range(1, 6))
+        levels = list(range(1, 4))
     else:
         levels = [taxonomy_level]
     # Loop over taxonomy levels

--- a/dap_aria_mapping/pipeline/novelty/openalex_topic_novelty.py
+++ b/dap_aria_mapping/pipeline/novelty/openalex_topic_novelty.py
@@ -61,7 +61,7 @@ def calculate_topic_novelty(
         )
         # Fetch topic names
         topic_names = get_topic_names(
-            taxonomy_class="cooccur", name_type="entity", level=level
+            taxonomy_class="cooccur", name_type="chatgpt", level=level
         )
         # Calculate novelty scores for topics
         topic_doc_novelty_df = nu.document_to_topic_novelty(work_novelty_df)

--- a/dap_aria_mapping/pipeline/novelty/patent_topic_novelty.py
+++ b/dap_aria_mapping/pipeline/novelty/patent_topic_novelty.py
@@ -58,7 +58,7 @@ def calculate_topic_novelty(
         )
         # Fetch topic names
         topic_names = get_topic_names(
-            taxonomy_class="cooccur", name_type="entity", level=level
+            taxonomy_class="cooccur", name_type="chatgpt", level=level
         )
         # Calculate novelty scores for topics
         topic_doc_novelty_df = nu.document_to_topic_novelty(patent_novelty_df, id_column="publication_number")

--- a/dap_aria_mapping/pipeline/novelty/patent_topic_novelty.py
+++ b/dap_aria_mapping/pipeline/novelty/patent_topic_novelty.py
@@ -42,7 +42,7 @@ def calculate_topic_novelty(
         min_doc_counts (int, optional): Minimum number of times a topic must appear in the corpus to be considered for including into the analysis outputs
     """
     if taxonomy_level == 0:
-        levels = list(range(1, 6))
+        levels = list(range(1, 4))
     else:
         levels = [taxonomy_level]
     # Loop over taxonomy levels

--- a/dap_aria_mapping/pipeline/semantic_taxonomy/make_taxonomy.py
+++ b/dap_aria_mapping/pipeline/semantic_taxonomy/make_taxonomy.py
@@ -1,24 +1,27 @@
-import warnings
-
-warnings.simplefilter(action="ignore", category=FutureWarning)
-import argparse, boto3, pickle, random
-from typing import Dict, Tuple, Any, Sequence
-import numpy as np
-import umap.umap_ as umap
-import matplotlib.pyplot as plt
-from toolz import pipe
-from functools import partial
-from sklearn.cluster import KMeans, AgglomerativeClustering, DBSCAN
-from hdbscan import HDBSCAN
-from dap_aria_mapping import PROJECT_DIR, BUCKET_NAME, logger, taxonomy
+import random
+import pickle
+import boto3
+import argparse
+from random import sample
+from dap_aria_mapping.getters.taxonomies import get_entity_embeddings
 from dap_aria_mapping.utils.semantics import (
     make_dataframe,
     run_clustering_generators,
     normalise_centroids,
     make_subplot_embeddings,
 )
-from dap_aria_mapping.getters.taxonomies import get_entity_embeddings
-from random import sample
+from dap_aria_mapping import PROJECT_DIR, BUCKET_NAME, logger, taxonomy
+from hdbscan import HDBSCAN
+from sklearn.cluster import KMeans, AgglomerativeClustering, DBSCAN
+from functools import partial
+from toolz import pipe
+import matplotlib.pyplot as plt
+import umap.umap_ as umap
+import numpy as np
+from typing import Dict, Tuple, Any, Sequence
+import warnings
+
+warnings.simplefilter(action="ignore", category=FutureWarning)
 
 METHODS = {
     "KMeans": KMeans,
@@ -42,7 +45,8 @@ def plot_centroids(cluster_outputs: Dict[str, Any]) -> plt.Figure:
         plt.Figure: A figure with a subplot for each level of clustering.
     """
     num_levels = len(cluster_outputs[-1]["silhouette"])
-    fig, axis = plt.subplots(1, num_levels, figsize=(int(num_levels * 8), 8), dpi=300)
+    fig, axis = plt.subplots(1, num_levels, figsize=(
+        int(num_levels * 8), 8), dpi=300)
     for idx, cdict in enumerate(cluster_outputs):
         if idx == 0:
             axis[idx].scatter(
@@ -78,7 +82,8 @@ def plot_imbalanced(
         plt.Figure: A figure with a subplot for each level of clustering.
     """
     num_levels = len(cluster_outputs[-1]["silhouette"])
-    fig, axis = plt.subplots(1, num_levels, figsize=(int(num_levels * 8), 8), dpi=300)
+    fig, axis = plt.subplots(1, num_levels, figsize=(
+        int(num_levels * 8), 8), dpi=300)
 
     for idx, (cdict, cluster) in enumerate(plot_dicts):
         labels = [int(e) for e in cdict.values()]
@@ -218,9 +223,11 @@ if __name__ == "__main__":
     logger.info("Creating dataframe of clustering results")
     dataframe = pipe(
         cluster_outputs[-1],
-        partial(make_dataframe, label=f"_{args.cluster_method}", cumulative=True),
+        partial(make_dataframe,
+                label=f"_{args.cluster_method}", cumulative=True),
         lambda df: df.rename(
-            columns={k: "Level_{}".format(int(v) + 1) for v, k in enumerate(df.columns)}
+            columns={k: "Level_{}".format(int(v) + 1)
+                     for v, k in enumerate(df.columns)}
         ),
         lambda df: df.reset_index()
         .rename(columns={"index": "Entity"})

--- a/dap_aria_mapping/pipeline/taxonomy_pruning/preprune_topics.py
+++ b/dap_aria_mapping/pipeline/taxonomy_pruning/preprune_topics.py
@@ -27,6 +27,7 @@ if __name__ == "__main__":
     except FileNotFoundError:
         logger.info("No entities.pkl found, creating new list.")
         entities = get_cooccurrence_taxonomy().index.tolist()
+        entities = entities[:35000]
 
     # Prompt chatGPT with the problem
     bot = ChatGPT(False)

--- a/dap_aria_mapping/utils/app_data_utils.py
+++ b/dap_aria_mapping/utils/app_data_utils.py
@@ -5,6 +5,7 @@ import polars as pl
 import pandas as pd
 from dap_aria_mapping.getters.taxonomies import get_topic_names
 
+
 def count_documents(doc_df: pl.DataFrame) -> pl.DataFrame:
     """takes a dataframe with documents (including their topic and year) 
     and generates a count of documents per topic per year
@@ -33,6 +34,7 @@ def expand_topic_col(topic_df: pl.DataFrame) -> pl.DataFrame:
         (pl.col("topic").str.split("_").arr.get(0)).alias("domain"),
         (pl.col("topic").str.split("_").arr.get(0) + "_" + pl.col("topic").str.split("_").arr.get(1)).alias("area"))
 
+
 def add_area_domain_chatgpt_names(df_with_topic_ids: pl.DataFrame) -> pl.DataFrame:
     """adds area, domain, and topic names to a dataframe tagged with topic, area, and domain ids
 
@@ -43,25 +45,25 @@ def add_area_domain_chatgpt_names(df_with_topic_ids: pl.DataFrame) -> pl.DataFra
         pl.DataFrame: dataframe tagged with topic names
     """
 
-    domain_names  = pl.DataFrame(
+    domain_names = pl.DataFrame(
         pd.DataFrame.from_dict(
-            get_topic_names("cooccur", "chatgpt", 1, n_top=35, postproc = True), 
-            orient= "index").rename_axis("domain").reset_index().rename(
-                columns = {"name": "domain_name"})[["domain", "domain_name"]])
-    area_names  = pl.DataFrame(
+            get_topic_names("cooccur", "chatgpt", 1, n_top=35, postproc=True),
+            orient="index").rename_axis("domain").reset_index().rename(
+                columns={"name": "domain_name"})[["domain", "domain_name"]])
+    area_names = pl.DataFrame(
         pd.DataFrame.from_dict(
-            get_topic_names("cooccur", "chatgpt", 2, n_top=35, postproc = True),
-            orient= "index").rename_axis("area").reset_index().rename(
-                columns = {"name": "area_name"})[["area", "area_name"]])
-    topic_names  = pl.DataFrame(
+            get_topic_names("cooccur", "chatgpt", 2, n_top=35, postproc=True),
+            orient="index").rename_axis("area").reset_index().rename(
+                columns={"name": "area_name"})[["area", "area_name"]])
+    topic_names = pl.DataFrame(
         pd.DataFrame.from_dict(
-            get_topic_names("cooccur", "chatgpt", 3, n_top=35, postproc = True),
-            orient= "index").rename_axis("topic").reset_index().rename(
-                columns = {"name": "topic_name"})[["topic", "topic_name"]])
-    
-    df_with_names = df_with_topic_ids.join(domain_names, on="domain", how="left")
+            get_topic_names("cooccur", "chatgpt", 3, n_top=35, postproc=True),
+            orient="index").rename_axis("topic").reset_index().rename(
+                columns={"name": "topic_name"})[["topic", "topic_name"]])
+
+    df_with_names = df_with_topic_ids.join(
+        domain_names, on="domain", how="left")
     df_with_names = df_with_names.join(area_names, on="area", how="left")
     df_with_names = df_with_names.join(topic_names, on="topic", how="left")
 
     return df_with_names
-


### PR DESCRIPTION
---

# Description

This PR generates the data needed for the quad chart on Change Makers. It shows a lot of files changes as it was rebased from dev, but the major files to review are:
`- pipeline/app_tables/quad_data.py`
`- analysis/pages/2_Change_Makers.py`

This has made the change makers tab very slow - the file generated from quad_data is very large and grouping it is very slow. I'm hoping that if we run this on a large server it should be ok? It uses polars so should be distributed. 

Also, I rebased it off of dev so although it's showing merge conflicts it should be able to be forced to merge.